### PR TITLE
Use SpyderPluginWidget instead of SpyderPluginMixin

### DIFF
--- a/spyder_unittest/unittestplugin.py
+++ b/spyder_unittest/unittestplugin.py
@@ -8,14 +8,12 @@
 """Unit testing Plugin."""
 
 # Third party imports
-from qtpy import PYQT5
 from qtpy.QtWidgets import QVBoxLayout
 from spyder.config.base import get_translation
 from spyder.plugins import SpyderPluginWidget
 from spyder.py3compat import getcwd
 from spyder.utils import icon_manager as ima
 from spyder.utils.qthelpers import create_action
-import spyder
 
 # Local imports
 from .widgets.unittestgui import UnitTestWidget, is_unittesting_installed
@@ -30,10 +28,8 @@ class UnitTestPlugin(SpyderPluginWidget):
 
     def __init__(self, parent=None):
         """Initialize plugin and corresponding widget."""
-        if spyder.version_info[0] < 4 and PYQT5:
-            SpyderPluginWidget.__init__(self, parent, main=parent)
-        else:
-            SpyderPluginWidget.__init__(self, parent)
+        SpyderPluginWidget.__init__(self, parent)
+        self.main = parent  # Spyder 3 compatibility
 
         # Create unit test widget
         self.unittestwidget = UnitTestWidget(self.main)

--- a/spyder_unittest/unittestplugin.py
+++ b/spyder_unittest/unittestplugin.py
@@ -11,11 +11,13 @@
 import os.path
 
 # Third party imports
+from qtpy import PYQT5
 from qtpy.QtWidgets import QVBoxLayout
 from spyder.config.base import get_translation
 from spyder.plugins import SpyderPluginWidget
 from spyder.utils import icon_manager as ima
 from spyder.utils.qthelpers import create_action
+import spyder
 
 # Local imports
 from .widgets.configdialog import Config
@@ -75,7 +77,10 @@ class UnitTestPlugin(SpyderPluginWidget):
 
     def __init__(self, parent=None):
         """Initialize plugin and corresponding widget."""
-        SpyderPluginWidget.__init__(self, parent)
+        if spyder.version_info[0] < 4 and PYQT5:
+            SpyderPluginWidget.__init__(self, parent, main=parent)
+        else:
+            SpyderPluginWidget.__init__(self, parent)
 
         # Add unit test widget in dockwindow
         self.unittestwidget = UnitTestWidgetInSpyder(self.main)

--- a/spyder_unittest/unittestplugin.py
+++ b/spyder_unittest/unittestplugin.py
@@ -24,7 +24,43 @@ from .widgets.unittestgui import UnitTestWidget, is_unittesting_installed
 _ = get_translation("unittest", dirname="spyder_unittest")
 
 
-class UnitTestPlugin(UnitTestWidget, SpyderPluginMixin):
+class UnitTestWidgetInSpyder(UnitTestWidget):
+    """
+    Unit test widget for use inside Spyder.
+
+    This class overrides some functions in `UnitTestWidget` to provide better
+    integration with Spyder.
+    """
+
+    def __init__(self, parent=None):
+        """Constructor."""
+        UnitTestWidget.__init__(self, parent)
+
+    def get_pythonpath(self):
+        """
+        Return directories to be added to the Python path.
+
+        Use Python path from Spyder. Overrides function in base class.
+
+        Returns
+        -------
+        list of str
+        """
+        return self.main.get_spyder_pythonpath()
+
+    def get_default_config(self):
+        """
+        Return configuration which is proposed when current config is invalid.
+
+        Propose to use directory of current file as working directory for
+        testing.
+        """
+        filename = self.main.editor.get_current_filename()
+        dirname = os.path.dirname(filename)
+        return Config(wdir=dirname)
+
+
+class UnitTestPlugin(UnitTestWidgetInSpyder, SpyderPluginMixin):
     """Unit testing."""
 
     CONF_SECTION = 'unittest'
@@ -32,7 +68,7 @@ class UnitTestPlugin(UnitTestWidget, SpyderPluginMixin):
 
     def __init__(self, parent=None):
         """Unit testing."""
-        UnitTestWidget.__init__(self, parent=parent)
+        UnitTestWidgetInSpyder.__init__(self, parent=parent)
         SpyderPluginMixin.__init__(self, parent)
 
         # Initialize plugin
@@ -87,29 +123,6 @@ class UnitTestPlugin(UnitTestWidget, SpyderPluginMixin):
     def apply_plugin_settings(self, options):
         """Apply configuration file's plugin settings."""
         pass
-
-    def get_pythonpath(self):
-        """
-        Return directories to be added to the Python path.
-
-        Use Python path from Spyder. Overrides function in base class.
-
-        Returns
-        -------
-        list of str
-        """
-        return self.main.get_spyder_pythonpath()
-
-    def get_default_config(self):
-        """
-        Return configuration which is proposed when current config is invalid.
-
-        Propose to use directory of current file as working directory for
-        testing.
-        """
-        filename = self.main.editor.get_current_filename()
-        dirname = os.path.dirname(filename)
-        return Config(wdir=dirname)
 
     # ----- Public API --------------------------------------------------------
     def maybe_configure_and_start(self):

--- a/spyder_unittest/unittestplugin.py
+++ b/spyder_unittest/unittestplugin.py
@@ -11,7 +11,6 @@
 import os.path
 
 # Third party imports
-from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QVBoxLayout
 from spyder.config.base import get_translation
 from spyder.plugins import SpyderPluginWidget
@@ -73,7 +72,6 @@ class UnitTestPlugin(SpyderPluginWidget):
     """Spyder plugin for unit testing."""
 
     CONF_SECTION = 'unittest'
-    edit_goto = Signal(str, int, str)
 
     def __init__(self, parent=None):
         """Initialize plugin and corresponding widget."""
@@ -112,7 +110,6 @@ class UnitTestPlugin(SpyderPluginWidget):
 
     def register_plugin(self):
         """Register plugin in Spyder's main window."""
-        self.edit_goto.connect(self.main.editor.load)
         self.main.add_dockwidget(self)
 
         unittesting_act = create_action(


### PR DESCRIPTION
This is in preparation for the new API in Spyder 4; see spyder-ide/spyder#3727. Also fixes #16.

----

The widget does no longer call the Spyder application, but all communication goes via the plugin. 

If the user has not yet selected a working dir in which to run the unit tests, then suggest the project directory, or the cwd if no project is opened. Fixes #22.