### PR TITLE
Fix parsing of module version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ import os.path as osp
 
 def get_version():
     """Get version from source file"""
-    with open("spyder_unittest/__init__.py") as f:
+    import codecs
+    with codecs.open("spyder_unittest/__init__.py", encoding="utf-8") as f:
         lines = f.read().splitlines()
         for l in lines:
             if "__version__" in l:


### PR DESCRIPTION
In the Debian autobuilders, the build fails with the following `UnicodeDecodeError` using Python 3.5:
```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 38: ordinal not in range(128)
```
Most likely, this is due to the copyright sign added as a result of the copyright header normalization.

The following patch fixes the problem.