### PR TITLE
Install the tests alongside the module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ testing frameworks.
 setup(
     name=LIBNAME,
     version=get_version(),
-    packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
+    packages=find_packages(),
     package_data={LIBNAME: get_package_data(LIBNAME, EXTLIST)},
     keywords=["Qt PyQt4 PyQt5 spyder plugins testing"],
     install_requires=REQUIREMENTS,

--- a/spyder_unittest/backend/tests/__init__.py
+++ b/spyder_unittest/backend/tests/__init__.py
@@ -3,5 +3,4 @@
 # Copyright © 2017 Spyder Project Contributors
 # Licensed under the terms of the MIT License
 # (see LICENSE.txt for details)
-
-# noqa: D104
+"""Tests for spyder_unittest.backend ."""

--- a/spyder_unittest/backend/tests/__init__.py
+++ b/spyder_unittest/backend/tests/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2017 Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+
+# noqa: D104

--- a/spyder_unittest/widgets/tests/__init__.py
+++ b/spyder_unittest/widgets/tests/__init__.py
@@ -3,5 +3,4 @@
 # Copyright © 2017 Spyder Project Contributors
 # Licensed under the terms of the MIT License
 # (see LICENSE.txt for details)
-
-# noqa: D104
+"""Tests for spyder_unittest.widgets ."""

--- a/spyder_unittest/widgets/tests/__init__.py
+++ b/spyder_unittest/widgets/tests/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2017 Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+
+# noqa: D104


### PR DESCRIPTION
Follow-up from #66. It would actually simplify the CI setup on Debian to have the tests installed with the module. This way, testing the packaged module for each supported Python version is just one `$py -m pytest --pyargs spyder_unittest` away, instead of having to manually extract the test suite.