### PR TITLE
Add framework registry for associating testing frameworks with runners

### DIFF
--- a/spyder_unittest/backend/frameworkregistry.py
+++ b/spyder_unittest/backend/frameworkregistry.py
@@ -26,7 +26,7 @@ class FrameworkRegistry():
 
     def __init__(self):
         """Initialize self."""
-        self.frameworks = {}
+        self.frameworks_dict = {}
 
     def register(self, framework, runner_class):
         """Register testing framework and its associated runner.
@@ -38,7 +38,7 @@ class FrameworkRegistry():
         runner_class : type
             Class used for creating tests runners for the framework.
         """
-        self.frameworks[framework] = runner_class
+        self.frameworks_dict[framework] = runner_class
 
     def create_runner(self, framework, widget, tempfilename):
         """Create test runner associated to some testing framework.
@@ -62,5 +62,10 @@ class FrameworkRegistry():
         KeyError
             Provided testing framework has not been registered.
         """
-        cls = self.frameworks[framework]
+        cls = self.frameworks_dict[framework]
         return cls(widget, tempfilename)
+
+    @property
+    def frameworks(self):
+        """Iterable with names of all frameworks."""
+        return self.frameworks_dict.keys()

--- a/spyder_unittest/backend/frameworkregistry.py
+++ b/spyder_unittest/backend/frameworkregistry.py
@@ -5,13 +5,40 @@
 # (see LICENSE.txt for details)
 """Keep track of testing frameworks and create test runners when requested."""
 
-# Local imports
-from spyder_unittest.backend.noserunner import NoseRunner
-from spyder_unittest.backend.pytestrunner import PyTestRunner
-
 
 class FrameworkRegistry():
-    """Registry of testing frameworks and their associated runners."""
+    """
+    Registry of testing frameworks and their associated runners.
+
+    The test runner for a framework is responsible for running the tests and
+    parsing the results. It should implement the interface of RunnerBase.
+
+    Frameworks should first be registered using `.register()`. This registry
+    can then create the assoicated test runner when `.create_runner()` is
+    called.
+
+    Attributes
+    ----------
+    framework : dict of (str, type)
+        Dictionary mapping names of testing frameworks to the types of the
+        associated runners.
+    """
+
+    def __init__(self):
+        """Initialize self."""
+        self.frameworks = {}
+
+    def register(self, framework, runner_class):
+        """Register testing framework and its associated runner.
+
+        Parameters
+        ----------
+        framework : str
+            Name of testing framework.
+        runner_class : type
+            Class used for creating tests runners for the framework.
+        """
+        self.frameworks[framework] = runner_class
 
     def create_runner(self, framework, widget, tempfilename):
         """Create test runner associated to some testing framework.
@@ -29,6 +56,11 @@ class FrameworkRegistry():
         -------
         RunnerBase
             Newly created test runner
+
+        Exceptions
+        ----------
+        KeyError
+            Provided testing framework has not been registered.
         """
-        cls = PyTestRunner if framework == 'py.test' else NoseRunner
+        cls = self.frameworks[framework]
         return cls(widget, tempfilename)

--- a/spyder_unittest/backend/frameworkregistry.py
+++ b/spyder_unittest/backend/frameworkregistry.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2017 Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+"""Keep track of testing frameworks and create test runners when requested."""
+
+# Local imports
+from spyder_unittest.backend.noserunner import NoseRunner
+from spyder_unittest.backend.pytestrunner import PyTestRunner
+
+
+class FrameworkRegistry():
+    """Registry of testing frameworks and their associated runners."""
+
+    def create_runner(self, framework, widget, tempfilename):
+        """Create test runner associated to some testing framework.
+
+        Parameters
+        ----------
+        framework : str
+            Name of testing framework.
+        widget : UnitTestWidget
+            Unit test widget which constructs the test runner.
+        resultfilename : str or None
+            Name of file in which to store test results. If None, use default.
+
+        Returns
+        -------
+        RunnerBase
+            Newly created test runner
+        """
+        cls = PyTestRunner if framework == 'py.test' else NoseRunner
+        return cls(widget, tempfilename)

--- a/spyder_unittest/backend/noserunner.py
+++ b/spyder_unittest/backend/noserunner.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2013 Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+"""Support for Nose framework."""
+
+# Local imports
+from spyder_unittest.backend.runnerbase import RunnerBase
+
+
+class NoseRunner(RunnerBase):
+    """Class for running tests within Nose framework."""
+
+    executable = 'nosetests'
+
+    def create_argument_list(self):
+        """Create argument list for testing process."""
+        return ['--with-xunit', '--xunit-file={}'.format(self.resultfilename)]

--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2013 Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+"""Support for py.test framework."""
+
+# Local imports
+from spyder_unittest.backend.runnerbase import RunnerBase
+
+
+class PyTestRunner(RunnerBase):
+    """Class for running tests within py.test framework."""
+
+    executable = 'py.test'
+
+    def create_argument_list(self):
+        """Create argument list for testing process (dummy)."""
+        return ['--junit-xml', self.resultfilename]

--- a/spyder_unittest/backend/tests/test_frameworkregistry.py
+++ b/spyder_unittest/backend/tests/test_frameworkregistry.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2017 Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+"""Tests for frameworkregistry.py"""
+
+# Third party imports
+import pytest
+
+# Local imports
+from spyder_unittest.backend.frameworkregistry import FrameworkRegistry
+
+
+class MockRunner:
+    def __init__(self, *args):
+        self.init_args = args
+
+
+def test_frameworkregistry_when_empty():
+    reg = FrameworkRegistry()
+    with pytest.raises(KeyError):
+        reg.create_runner('foo', None, 'temp.txt')
+
+def test_frameworkregistry_after_registering():
+    reg = FrameworkRegistry()
+    reg.register('foo', MockRunner)
+    runner = reg.create_runner('foo', None, 'temp.txt')
+    assert isinstance(runner, MockRunner)
+    assert runner.init_args == (None, 'temp.txt')

--- a/spyder_unittest/backend/tests/test_frameworkregistry.py
+++ b/spyder_unittest/backend/tests/test_frameworkregistry.py
@@ -29,3 +29,11 @@ def test_frameworkregistry_after_registering():
     runner = reg.create_runner('foo', None, 'temp.txt')
     assert isinstance(runner, MockRunner)
     assert runner.init_args == (None, 'temp.txt')
+
+
+def test_frameworkregistry_frameworks():
+    reg = FrameworkRegistry()
+    frameworks = {'spam', 'ham', 'eggs'}
+    for name in frameworks:
+        reg.register(name, object)
+    assert frameworks == reg.frameworks

--- a/spyder_unittest/backend/tests/test_frameworkregistry.py
+++ b/spyder_unittest/backend/tests/test_frameworkregistry.py
@@ -22,6 +22,7 @@ def test_frameworkregistry_when_empty():
     with pytest.raises(KeyError):
         reg.create_runner('foo', None, 'temp.txt')
 
+
 def test_frameworkregistry_after_registering():
     reg = FrameworkRegistry()
     reg.register('foo', MockRunner)

--- a/spyder_unittest/backend/tests/test_frameworkregistry.py
+++ b/spyder_unittest/backend/tests/test_frameworkregistry.py
@@ -36,4 +36,4 @@ def test_frameworkregistry_frameworks():
     frameworks = {'spam', 'ham', 'eggs'}
     for name in frameworks:
         reg.register(name, object)
-    assert frameworks == reg.frameworks
+    assert frameworks == set(reg.frameworks)

--- a/spyder_unittest/backend/tests/test_pytestrunner.py
+++ b/spyder_unittest/backend/tests/test_pytestrunner.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2017 Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+"""Tests for pytestrunner.py"""
+
+# Standard library imports
+import os
+
+# Local imports
+from spyder_unittest.backend.pytestrunner import PyTestRunner
+from spyder_unittest.widgets.configdialog import Config
+
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock  # Python 2
+
+
+def test_pytestrunner_start(monkeypatch):
+    MockQProcess = Mock()
+    monkeypatch.setattr('spyder_unittest.backend.runnerbase.QProcess',
+                        MockQProcess)
+    mock_process = MockQProcess()
+    mock_process.systemEnvironment = lambda: ['VAR=VALUE', 'PYTHONPATH=old']
+
+    MockEnvironment = Mock()
+    monkeypatch.setattr(
+        'spyder_unittest.backend.runnerbase.QProcessEnvironment',
+        MockEnvironment)
+    mock_environment = MockEnvironment()
+
+    mock_remove = Mock(side_effect=OSError())
+    monkeypatch.setattr('spyder_unittest.backend.runnerbase.os.remove',
+                        mock_remove)
+
+    runner = PyTestRunner(None, 'results')
+    config = Config('py.test', 'wdir')
+    runner.start(config, ['pythondir'])
+
+    mock_process.setWorkingDirectory.assert_called_once_with('wdir')
+    mock_process.finished.connect.assert_called_once_with(runner.finished)
+    mock_process.setProcessEnvironment.assert_called_once_with(
+        mock_environment)
+    executable_name = 'py.test.exe' if os.name == 'nt' else 'py.test'
+    mock_process.start.assert_called_once_with(executable_name,
+                                               ['--junit-xml', 'results'])
+
+    mock_environment.insert.assert_any_call('VAR', 'VALUE')
+    # mock_environment.insert.assert_any_call('PYTHONPATH', 'pythondir:old')
+    # TODO: Find out why above test fails
+    mock_remove.called_once_with('results')

--- a/spyder_unittest/widgets/configdialog.py
+++ b/spyder_unittest/widgets/configdialog.py
@@ -97,7 +97,9 @@ class ConfigDialog(QDialog):
 
         self.framework_combobox.setCurrentIndex(-1)
         if config.framework:
-            self.framework_combobox.setCurrentText(config.framework)
+            index = self.framework_combobox.findText(config.framework)
+            if index != -1:
+                self.framework_combobox.setCurrentIndex(index)
         self.wdir_lineedit.setText(config.wdir)
 
     @Slot(int)

--- a/spyder_unittest/widgets/configdialog.py
+++ b/spyder_unittest/widgets/configdialog.py
@@ -37,20 +37,21 @@ class ConfigDialog(QDialog):
     """
     Dialog window for specifying test configuration.
 
-    The window contains two radio buttons (for 'py,test' and 'nose'),
-    a line edit box for specifying the working directory, a button to
-    use a file browser for selecting the directory, and OK and Cancel
-    buttons. Initially, neither radio button is selected and the OK
-    button is disabled. Selecting a radio button enabled the OK
-    button.
+    The window contains a combobox with all the frameworks, a line edit box for
+    specifying the working directory, a button to use a file browser for
+    selecting the directory, and OK and Cancel buttons. Initially, no framework
+    is selected and the OK button is disabled. Selecting a framework enables
+    the OK button.
     """
 
-    def __init__(self, config, parent=None):
+    def __init__(self, frameworks, config, parent=None):
         """
         Construct a dialog window.
 
         Parameters
         ----------
+        frameworks : iterable of str
+            Names of all supported frameworks
         config : Config
             Initial configuration
         parent : QWidget
@@ -62,7 +63,6 @@ class ConfigDialog(QDialog):
         framework_layout = QHBoxLayout()
         framework_label = QLabel(_('Test framework'))
         framework_layout.addWidget(framework_label)
-        frameworks = ['py.test', 'nose']
         self.framework_combobox = QComboBox(self)
         for framework in frameworks:
             self.framework_combobox.addItem(framework)
@@ -131,14 +131,14 @@ class ConfigDialog(QDialog):
         return Config(framework=framework, wdir=self.wdir_lineedit.text())
 
 
-def ask_for_config(config, parent=None):
+def ask_for_config(frameworks, config, parent=None):
     """
     Ask user to specify a test configuration.
 
     This is a convenience function which displays a modal dialog window
     of type `ConfigDialog`.
     """
-    dialog = ConfigDialog(config, parent)
+    dialog = ConfigDialog(frameworks, config, parent)
     result = dialog.exec_()
     if result == QDialog.Accepted:
         return dialog.get_config()
@@ -146,5 +146,6 @@ def ask_for_config(config, parent=None):
 
 if __name__ == '__main__':
     app = QApplication([])
+    frameworks = ['nose', 'py.test', 'unittest']
     config = Config(framework=None, wdir=getcwd())
-    print(ask_for_config(config))
+    print(ask_for_config(frameworks, config))

--- a/spyder_unittest/widgets/tests/test_configdialog.py
+++ b/spyder_unittest/widgets/tests/test_configdialog.py
@@ -28,7 +28,7 @@ def test_configdialog_sets_initial_config(qtbot):
 def test_configdialog_click_pytest(qtbot):
     configdialog = ConfigDialog(default_config())
     qtbot.addWidget(configdialog)
-    configdialog.pytest_button.click()
+    configdialog.framework_combobox.setCurrentText('py.test')
     assert configdialog.get_config().framework == 'py.test'
 
 
@@ -48,7 +48,7 @@ def test_configdialog_ok_setting_framework_initially_enables_ok(qtbot):
 def test_configdialog_clicking_pytest_enables_ok(qtbot):
     configdialog = ConfigDialog(default_config())
     qtbot.addWidget(configdialog)
-    configdialog.pytest_button.click()
+    configdialog.framework_combobox.setCurrentText('py.test')
     assert configdialog.buttons.button(QDialogButtonBox.Ok).isEnabled()
 
 

--- a/spyder_unittest/widgets/tests/test_configdialog.py
+++ b/spyder_unittest/widgets/tests/test_configdialog.py
@@ -38,7 +38,7 @@ def test_configdialog_sets_initial_config(qtbot):
 def test_configdialog_click_pytest(qtbot):
     configdialog = ConfigDialog(frameworks, default_config())
     qtbot.addWidget(configdialog)
-    configdialog.framework_combobox.setCurrentText('py.test')
+    configdialog.framework_combobox.setCurrentIndex(1)
     assert configdialog.get_config().framework == 'py.test'
 
 
@@ -58,7 +58,7 @@ def test_configdialog_ok_setting_framework_initially_enables_ok(qtbot):
 def test_configdialog_clicking_pytest_enables_ok(qtbot):
     configdialog = ConfigDialog(frameworks, default_config())
     qtbot.addWidget(configdialog)
-    configdialog.framework_combobox.setCurrentText('py.test')
+    configdialog.framework_combobox.setCurrentIndex(1)
     assert configdialog.buttons.button(QDialogButtonBox.Ok).isEnabled()
 
 

--- a/spyder_unittest/widgets/tests/test_configdialog.py
+++ b/spyder_unittest/widgets/tests/test_configdialog.py
@@ -14,46 +14,56 @@ from qtpy.QtWidgets import QDialogButtonBox
 # Local imports
 from spyder_unittest.widgets.configdialog import Config, ConfigDialog
 
+frameworks = ['nose', 'py.test']
+
 
 def default_config():
     return Config(framework=None, wdir=os.getcwd())
 
 
+def test_configdialog_uses_frameworks(qtbot):
+    frameworks = ['spam', 'ham', 'eggs']
+    configdialog = ConfigDialog(frameworks, default_config())
+    assert configdialog.framework_combobox.count() == len(frameworks)
+    for i in range(len(frameworks)):
+        assert configdialog.framework_combobox.itemText(i) == frameworks[i]
+
+
 def test_configdialog_sets_initial_config(qtbot):
     config = default_config()
-    configdialog = ConfigDialog(config)
+    configdialog = ConfigDialog(frameworks, config)
     assert configdialog.get_config() == config
 
 
 def test_configdialog_click_pytest(qtbot):
-    configdialog = ConfigDialog(default_config())
+    configdialog = ConfigDialog(frameworks, default_config())
     qtbot.addWidget(configdialog)
     configdialog.framework_combobox.setCurrentText('py.test')
     assert configdialog.get_config().framework == 'py.test'
 
 
 def test_configdialog_ok_initially_disabled(qtbot):
-    configdialog = ConfigDialog(default_config())
+    configdialog = ConfigDialog(frameworks, default_config())
     qtbot.addWidget(configdialog)
     assert not configdialog.buttons.button(QDialogButtonBox.Ok).isEnabled()
 
 
 def test_configdialog_ok_setting_framework_initially_enables_ok(qtbot):
     config = Config(framework='py.test', wdir=os.getcwd())
-    configdialog = ConfigDialog(config)
+    configdialog = ConfigDialog(frameworks, config)
     qtbot.addWidget(configdialog)
     assert configdialog.buttons.button(QDialogButtonBox.Ok).isEnabled()
 
 
 def test_configdialog_clicking_pytest_enables_ok(qtbot):
-    configdialog = ConfigDialog(default_config())
+    configdialog = ConfigDialog(frameworks, default_config())
     qtbot.addWidget(configdialog)
     configdialog.framework_combobox.setCurrentText('py.test')
     assert configdialog.buttons.button(QDialogButtonBox.Ok).isEnabled()
 
 
 def test_configdialog_wdir_lineedit(qtbot):
-    configdialog = ConfigDialog(default_config())
+    configdialog = ConfigDialog(frameworks, default_config())
     qtbot.addWidget(configdialog)
     wdir = os.path.normpath(os.path.join(os.getcwd(), os.path.pardir))
     configdialog.wdir_lineedit.setText(wdir)
@@ -61,7 +71,7 @@ def test_configdialog_wdir_lineedit(qtbot):
 
 
 def test_configdialog_wdir_button(qtbot, monkeypatch):
-    configdialog = ConfigDialog(default_config())
+    configdialog = ConfigDialog(frameworks, default_config())
     qtbot.addWidget(configdialog)
     wdir = os.path.normpath(os.path.join(os.getcwd(), os.path.pardir))
     monkeypatch.setattr(

--- a/spyder_unittest/widgets/tests/test_configdialog.py
+++ b/spyder_unittest/widgets/tests/test_configdialog.py
@@ -25,8 +25,8 @@ def test_configdialog_uses_frameworks(qtbot):
     frameworks = ['spam', 'ham', 'eggs']
     configdialog = ConfigDialog(frameworks, default_config())
     assert configdialog.framework_combobox.count() == len(frameworks)
-    for i in range(len(frameworks)):
-        assert configdialog.framework_combobox.itemText(i) == frameworks[i]
+    for i, framework in enumerate(frameworks):
+        assert configdialog.framework_combobox.itemText(i) == framework
 
 
 def test_configdialog_sets_initial_config(qtbot):

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -25,6 +25,8 @@ from spyder.widgets.variableexplorer.texteditor import TextEditor
 
 # Local imports
 from spyder_unittest.backend.frameworkregistry import FrameworkRegistry
+from spyder_unittest.backend.noserunner import NoseRunner
+from spyder_unittest.backend.pytestrunner import PyTestRunner
 from spyder_unittest.backend.runnerbase import Category
 from spyder_unittest.widgets.configdialog import Config, ask_for_config
 
@@ -42,6 +44,9 @@ COLORS = {
     Category.FAIL: QBrush(QColor("#FF0000")),
     Category.SKIP: QBrush(QColor("#C5C5C5"))
 }
+
+# Supported testing framework
+FRAMEWORKS = {'nose': NoseRunner, 'py.test': PyTestRunner}
 
 
 def is_unittesting_installed():
@@ -61,6 +66,8 @@ class UnitTestWidget(QWidget):
         Configuration for running tests.
     default_wdir : str
         Default choice of working directory.
+    framework_registry : FrameworkRegistry
+        Registry of supported testing frameworks.
     pythonpath : list of str
         Directories to be added to the Python path when running tests.
     testrunner : TestRunner or None
@@ -85,10 +92,13 @@ class UnitTestWidget(QWidget):
         self.config = None
         self.pythonpath = None
         self.default_wdir = None
-        self.framework_registry = FrameworkRegistry()
         self.testrunner = None
         self.output = None
         self.datatree = UnitTestDataTree(self)
+
+        self.framework_registry = FrameworkRegistry()
+        for (name, runner) in FRAMEWORKS.items():
+            self.framework_registry.register(name, runner)
 
         self.start_button = create_toolbutton(self, text_beside_icon=True)
         self.set_running_state(False)

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -24,7 +24,9 @@ from spyder.utils.qthelpers import create_action, create_toolbutton
 from spyder.widgets.variableexplorer.texteditor import TextEditor
 
 # Local imports
-from spyder_unittest.backend.testrunner import Category, TestRunner
+from spyder_unittest.backend.noserunner import NoseRunner
+from spyder_unittest.backend.pytestrunner import PyTestRunner
+from spyder_unittest.backend.runnerbase import Category
 from spyder_unittest.widgets.configdialog import Config, ask_for_config
 
 # This is needed for testing this module as a stand alone script
@@ -199,7 +201,8 @@ class UnitTestWidget(QWidget):
         pythonpath = self.pythonpath
         self.datatree.clear()
         tempfilename = get_conf_path('unittest.results')
-        self.testrunner = TestRunner(self, tempfilename)
+        cls = PyTestRunner if config.framework == 'py.test' else NoseRunner
+        self.testrunner = cls(self, tempfilename)
         self.testrunner.sig_finished.connect(self.process_finished)
 
         try:

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -172,7 +172,8 @@ class UnitTestWidget(QWidget):
             oldconfig = self.config
         else:
             oldconfig = Config(wdir=self.default_wdir)
-        config = ask_for_config(oldconfig)
+        frameworks = sorted(self.framework_registry.frameworks)
+        config = ask_for_config(frameworks, oldconfig)
         if config:
             self.config = config
 

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -24,8 +24,7 @@ from spyder.utils.qthelpers import create_action, create_toolbutton
 from spyder.widgets.variableexplorer.texteditor import TextEditor
 
 # Local imports
-from spyder_unittest.backend.noserunner import NoseRunner
-from spyder_unittest.backend.pytestrunner import PyTestRunner
+from spyder_unittest.backend.frameworkregistry import FrameworkRegistry
 from spyder_unittest.backend.runnerbase import Category
 from spyder_unittest.widgets.configdialog import Config, ask_for_config
 
@@ -86,6 +85,7 @@ class UnitTestWidget(QWidget):
         self.config = None
         self.pythonpath = None
         self.default_wdir = None
+        self.framework_registry = FrameworkRegistry()
         self.testrunner = None
         self.output = None
         self.datatree = UnitTestDataTree(self)
@@ -201,8 +201,8 @@ class UnitTestWidget(QWidget):
         pythonpath = self.pythonpath
         self.datatree.clear()
         tempfilename = get_conf_path('unittest.results')
-        cls = PyTestRunner if config.framework == 'py.test' else NoseRunner
-        self.testrunner = cls(self, tempfilename)
+        self.testrunner = self.framework_registry.create_runner(
+            config.framework, self, tempfilename)
         self.testrunner.sig_finished.connect(self.process_finished)
 
         try:


### PR DESCRIPTION
The idea is that every testing framework has a class associated with it for running the tests and parsing the results. The framework registry keeps track of the supported testing frameworks, and creates the runners. This allows for easier extension to other testing frameworks (like unittest), possibly using additional plugins in the future. Fixes #41.