### PR TITLE
Support unittest

### DIFF
--- a/spyder_unittest/backend/tests/test_unittestrunner.py
+++ b/spyder_unittest/backend/tests/test_unittestrunner.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2017 Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+"""Tests for unittestrunner.py"""
+
+# Local imports
+from spyder_unittest.backend.runnerbase import Category
+from spyder_unittest.backend.unittestrunner import UnittestRunner
+
+
+def test_unittestrunner_load_data():
+    output = """test_isupper (teststringmethods.TestStringMethods) ... ok
+test_split (teststringmethods.TestStringMethods) ... ok
+extra text\n"""
+    runner = UnittestRunner(None)
+    res = runner.load_data(output)
+    assert len(res) == 2
+
+    assert res[0].category == Category.OK
+    assert res[0].status == 'ok'
+    assert res[0].name == 'teststringmethods.TestStringMethods.test_isupper'
+    assert res[0].message == ''
+    assert res[0].extra_text == ''
+
+    assert res[1].category == Category.OK
+    assert res[1].status == 'ok'
+    assert res[1].name == 'teststringmethods.TestStringMethods.test_split'
+    assert res[1].message == ''
+    assert res[1].extra_text == 'extra text\n'

--- a/spyder_unittest/backend/tests/test_unittestrunner.py
+++ b/spyder_unittest/backend/tests/test_unittestrunner.py
@@ -29,3 +29,17 @@ extra text\n"""
     assert res[1].name == 'teststringmethods.TestStringMethods.test_split'
     assert res[1].message == ''
     assert res[1].extra_text == 'extra text\n'
+
+
+def test_try_parse_header_with_ok():
+    runner = UnittestRunner(None)
+    text = 'test_isupper (testfoo.TestStringMethods) ... ok'
+    res = runner.try_parse_result(text)
+    assert res == ('test_isupper', 'testfoo.TestStringMethods', 'ok')
+
+
+def test_try_parse_header_starting_with_digit():
+    runner = UnittestRunner(None)
+    text = '0est_isupper (testfoo.TestStringMethods) ... ok'
+    res = runner.try_parse_result(text)
+    assert res is None

--- a/spyder_unittest/backend/tests/test_unittestrunner.py
+++ b/spyder_unittest/backend/tests/test_unittestrunner.py
@@ -31,7 +31,7 @@ extra text\n"""
     assert res[1].extra_text == 'extra text\n'
 
 
-def test_unittestrunner_removes_footer():
+def test_unittestrunner_load_data_removes_footer():
     output = """test1 (test_foo.Bar) ... ok
 
 ----------------------------------------------------------------------
@@ -45,8 +45,35 @@ OK
     assert res[0].category == Category.OK
     assert res[0].status == 'ok'
     assert res[0].name == 'test_foo.Bar.test1'
-    assert res[0].message == ''
     assert res[0].extra_text == ''
+
+
+def test_unittestrunner_load_data_with_exception():
+    output = """test1 (test_foo.Bar) ... FAIL
+test2 (test_foo.Bar) ... ok
+
+======================================================================
+FAIL: test1 (test_foo.Bar)
+----------------------------------------------------------------------
+Traceback (most recent call last):
+  File "/somepath/test_foo.py", line 5, in test1
+    self.assertEqual(1, 2)
+AssertionError: 1 != 2
+"""
+    runner = UnittestRunner(None)
+    res = runner.load_data(output)
+    assert len(res) == 2
+
+    assert res[0].category == Category.FAIL
+    assert res[0].status == 'FAIL'
+    assert res[0].name == 'test_foo.Bar.test1'
+    assert res[0].extra_text.startswith('Traceback')
+    assert res[0].extra_text.endswith('AssertionError: 1 != 2\n')
+
+    assert res[1].category == Category.OK
+    assert res[1].status == 'ok'
+    assert res[1].name == 'test_foo.Bar.test2'
+    assert res[1].extra_text == ''
 
 
 def test_try_parse_header_with_ok():

--- a/spyder_unittest/backend/tests/test_unittestrunner.py
+++ b/spyder_unittest/backend/tests/test_unittestrunner.py
@@ -31,6 +31,24 @@ extra text\n"""
     assert res[1].extra_text == 'extra text\n'
 
 
+def test_unittestrunner_removes_footer():
+    output = """test1 (test_foo.Bar) ... ok
+
+----------------------------------------------------------------------
+Ran 1 test in 0.000s
+
+OK
+"""
+    runner = UnittestRunner(None)
+    res = runner.load_data(output)
+    assert len(res) == 1
+    assert res[0].category == Category.OK
+    assert res[0].status == 'ok'
+    assert res[0].name == 'test_foo.Bar.test1'
+    assert res[0].message == ''
+    assert res[0].extra_text == ''
+
+
 def test_try_parse_header_with_ok():
     runner = UnittestRunner(None)
     text = 'test_isupper (testfoo.TestStringMethods) ... ok'

--- a/spyder_unittest/backend/tests/test_unittestrunner.py
+++ b/spyder_unittest/backend/tests/test_unittestrunner.py
@@ -80,7 +80,22 @@ def test_try_parse_header_with_ok():
     runner = UnittestRunner(None)
     text = 'test_isupper (testfoo.TestStringMethods) ... ok'
     res = runner.try_parse_result(text)
-    assert res == ('test_isupper', 'testfoo.TestStringMethods', 'ok')
+    assert res == ('test_isupper', 'testfoo.TestStringMethods', 'ok', '')
+
+
+def test_try_parse_header_with_xfail():
+    runner = UnittestRunner(None)
+    text = 'test_isupper (testfoo.TestStringMethods) ... expected failure'
+    res = runner.try_parse_result(text)
+    assert res == ('test_isupper', 'testfoo.TestStringMethods',
+                   'expected failure', '')
+
+
+def test_try_parse_header_with_message():
+    runner = UnittestRunner(None)
+    text = "test_nothing (testfoo.Tests) ... skipped 'msg'"
+    res = runner.try_parse_result(text)
+    assert res == ('test_nothing', 'testfoo.Tests', 'skipped', 'msg')
 
 
 def test_try_parse_header_starting_with_digit():

--- a/spyder_unittest/backend/unittestrunner.py
+++ b/spyder_unittest/backend/unittestrunner.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2017 Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+"""Support for unittest framework."""
+
+# Third party imports
+from qtpy.QtCore import QTextCodec
+from spyder.py3compat import to_text_string
+
+# Local imports
+from spyder_unittest.backend.runnerbase import Category, RunnerBase, TestResult
+
+
+class UnittestRunner(RunnerBase):
+    """Class for running tests with unittest module in standard library."""
+
+    executable = 'python'
+
+    def create_argument_list(self):
+        """Create argument list for testing process."""
+        return ['-m', 'unittest', '-v']
+
+    def finished(self):
+        """
+        Called when the unit test process has finished.
+
+        This function reads the results and emits `sig_finished`.
+        """
+        qbytearray = self.process.readAllStandardOutput()
+        locale_codec = QTextCodec.codecForLocale()
+        output = to_text_string(locale_codec.toUnicode(qbytearray.data()))
+        testresults = self.load_data(output)  # overrides base class method
+        self.sig_finished.emit(testresults, output)
+
+    def load_data(self, output):
+        """
+        Read and parse unit test results.
+
+        Returns
+        -------
+        list of TestResult
+            Unit test results.
+        """
+        return [TestResult(Category.OK, '', 'all', '', 0, output)]

--- a/spyder_unittest/backend/unittestrunner.py
+++ b/spyder_unittest/backend/unittestrunner.py
@@ -54,7 +54,8 @@ class UnittestRunner(RunnerBase):
             if data:
                 if olddata:
                     name = olddata[1] + '.' + olddata[0]
-                    tr = TestResult(Category.OK, olddata[2], name, '', 0, text)
+                    cat = Category.OK if olddata[2] == 'ok' else Category.FAIL
+                    tr = TestResult(cat, olddata[2], name, '', 0, text)
                     res.append(tr)
                 olddata = data
                 text = ""
@@ -62,7 +63,8 @@ class UnittestRunner(RunnerBase):
                 text += line + '\n'
         if olddata:
             name = olddata[1] + '.' + olddata[0]
-            tr = TestResult(Category.OK, olddata[2], name, '', 0, text)
+            cat = Category.OK if olddata[2] == 'ok' else Category.FAIL
+            tr = TestResult(cat, olddata[2], name, '', 0, text)
             res.append(tr)
         return res
 
@@ -77,9 +79,8 @@ class UnittestRunner(RunnerBase):
             strings: the name of the test function, the name of the test class,
             and the test result. Otherwise, return None.
         """
-        regexp = r'([^\d\W]\w*) \(([^\d\W][\w.]*)\) \.\.\. (ok)'
+        regexp = r'([^\d\W]\w*) \(([^\d\W][\w.]*)\) \.\.\. (ok|FAIL|ERROR)'
         match = re.fullmatch(regexp, line)
-        print(repr(line), match)
         if match:
             return match.groups()
         else:

--- a/spyder_unittest/backend/unittestrunner.py
+++ b/spyder_unittest/backend/unittestrunner.py
@@ -34,7 +34,6 @@ class UnittestRunner(RunnerBase):
         qbytearray = self.process.readAllStandardOutput()
         locale_codec = QTextCodec.codecForLocale()
         output = to_text_string(locale_codec.toUnicode(qbytearray.data()))
-        print(repr(output))
         testresults = self.load_data(output)  # overrides base class method
         self.sig_finished.emit(testresults, output)
 

--- a/spyder_unittest/backend/unittestrunner.py
+++ b/spyder_unittest/backend/unittestrunner.py
@@ -23,7 +23,7 @@ class UnittestRunner(RunnerBase):
 
     def create_argument_list(self):
         """Create argument list for testing process."""
-        return ['-m', 'unittest', '-v']
+        return ['-m', 'unittest', 'discover', '-v']
 
     def finished(self):
         """
@@ -34,6 +34,7 @@ class UnittestRunner(RunnerBase):
         qbytearray = self.process.readAllStandardOutput()
         locale_codec = QTextCodec.codecForLocale()
         output = to_text_string(locale_codec.toUnicode(qbytearray.data()))
+        print(repr(output))
         testresults = self.load_data(output)  # overrides base class method
         self.sig_finished.emit(testresults, output)
 
@@ -101,8 +102,8 @@ class UnittestRunner(RunnerBase):
         """
         regexp = (r'([^\d\W]\w*) \(([^\d\W][\w.]*)\) \.\.\. '
                   '(ok|FAIL|ERROR|skipped|expected failure|unexpected success)'
-                  "( '([^']*)')?")
-        match = re.fullmatch(regexp, line)
+                  "( '([^']*)')?\Z")
+        match = re.match(regexp, line)
         if match:
             msg = match.groups()[4] or ''
             return match.groups()[:3] + (msg, )
@@ -124,8 +125,8 @@ class UnittestRunner(RunnerBase):
             return None
         if not all(char == '=' for char in lines[line_index + 1]):
             return None
-        regexp = r'\w+: ([^\d\W]\w*) \(([^\d\W][\w.]*)\)'
-        match = re.fullmatch(regexp, lines[line_index + 2])
+        regexp = r'\w+: ([^\d\W]\w*) \(([^\d\W][\w.]*)\)\Z'
+        match = re.match(regexp, lines[line_index + 2])
         if not match:
             return None
         if not all(char == '-' for char in lines[line_index + 3]):

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -28,6 +28,7 @@ from spyder_unittest.backend.frameworkregistry import FrameworkRegistry
 from spyder_unittest.backend.noserunner import NoseRunner
 from spyder_unittest.backend.pytestrunner import PyTestRunner
 from spyder_unittest.backend.runnerbase import Category
+from spyder_unittest.backend.unittestrunner import UnittestRunner
 from spyder_unittest.widgets.configdialog import Config, ask_for_config
 
 # This is needed for testing this module as a stand alone script
@@ -46,7 +47,11 @@ COLORS = {
 }
 
 # Supported testing framework
-FRAMEWORKS = {'nose': NoseRunner, 'py.test': PyTestRunner}
+FRAMEWORKS = {
+    'nose': NoseRunner,
+    'py.test': PyTestRunner,
+    'unittest': UnittestRunner
+}
 
 
 def is_unittesting_installed():


### PR DESCRIPTION
This implements support for running tests using the unittest package in the standard Python library. Fixes #4.

The parsing of the unittest output is not very robust and easily confused by print statements in the tests. I am opening a separate issue for this.