### PR TITLE
Shorten test name displayed in widget

### DIFF
--- a/spyder_unittest/backend/runnerbase.py
+++ b/spyder_unittest/backend/runnerbase.py
@@ -26,7 +26,7 @@ except KeyError as error:
 
 # Class representing test results
 TestResult = namedtuple('TestResult', [
-    'category', 'status', 'name', 'message', 'time', 'extra_text'
+    'category', 'status', 'name', 'module', 'message', 'time', 'extra_text'
 ])
 
 
@@ -189,8 +189,8 @@ class RunnerBase(QObject):
         for testcase in data:
             category = Category.OK
             status = 'ok'
-            name = '{0}.{1}'.format(
-                testcase.get('classname'), testcase.get('name'))
+            module = testcase.get('classname')
+            name = testcase.get('name')
             message = ''
             time = float(testcase.get('time'))
             extras = []
@@ -221,6 +221,7 @@ class RunnerBase(QObject):
 
             extra_text = '\n\n'.join(extras)
             testresults.append(
-                TestResult(category, status, name, message, time, extra_text))
+                TestResult(category, status, name, module, message, time,
+                           extra_text))
 
         return testresults

--- a/spyder_unittest/backend/tests/test_runnerbase.py
+++ b/spyder_unittest/backend/tests/test_runnerbase.py
@@ -27,21 +27,24 @@ def test_baserunner_load_data(tmpdir):
 
     assert results[0].category == Category.OK
     assert results[0].status == 'ok'
-    assert results[0].name == 'test_foo.test1'
+    assert results[0].name == 'test1'
+    assert results[0].module == 'test_foo'
     assert results[0].message == ''
     assert results[0].time == 0.04
     assert results[0].extra_text == ''
 
     assert results[1].category == Category.FAIL
     assert results[1].status == 'failure'
-    assert results[1].name == 'test_foo.test2'
+    assert results[1].name == 'test2'
+    assert results[1].module == 'test_foo'
     assert results[1].message == 'failure message'
     assert results[1].time == 0.01
     assert results[1].extra_text == 'text'
 
     assert results[2].category == Category.SKIP
     assert results[2].status == 'skipped'
-    assert results[2].name == 'test_foo.test3'
+    assert results[2].name == 'test3'
+    assert results[2].module == 'test_foo'
     assert results[2].message == 'skip message'
     assert results[2].time == 0.05
     assert results[2].extra_text == 'text2'

--- a/spyder_unittest/backend/tests/test_unittestrunner.py
+++ b/spyder_unittest/backend/tests/test_unittestrunner.py
@@ -20,13 +20,15 @@ extra text\n"""
 
     assert res[0].category == Category.OK
     assert res[0].status == 'ok'
-    assert res[0].name == 'teststringmethods.TestStringMethods.test_isupper'
+    assert res[0].name == 'test_isupper'
+    assert res[0].module == 'teststringmethods.TestStringMethods'
     assert res[0].message == ''
     assert res[0].extra_text == ''
 
     assert res[1].category == Category.OK
     assert res[1].status == 'ok'
-    assert res[1].name == 'teststringmethods.TestStringMethods.test_split'
+    assert res[1].name == 'test_split'
+    assert res[1].module == 'teststringmethods.TestStringMethods'
     assert res[1].message == ''
     assert res[1].extra_text == 'extra text\n'
 
@@ -44,7 +46,8 @@ OK
     assert len(res) == 1
     assert res[0].category == Category.OK
     assert res[0].status == 'ok'
-    assert res[0].name == 'test_foo.Bar.test1'
+    assert res[0].name == 'test1'
+    assert res[0].module == 'test_foo.Bar'
     assert res[0].extra_text == ''
 
 
@@ -66,13 +69,15 @@ AssertionError: 1 != 2
 
     assert res[0].category == Category.FAIL
     assert res[0].status == 'FAIL'
-    assert res[0].name == 'test_foo.Bar.test1'
+    assert res[0].name == 'test1'
+    assert res[0].module == 'test_foo.Bar'
     assert res[0].extra_text.startswith('Traceback')
     assert res[0].extra_text.endswith('AssertionError: 1 != 2\n')
 
     assert res[1].category == Category.OK
     assert res[1].status == 'ok'
-    assert res[1].name == 'test_foo.Bar.test2'
+    assert res[1].name == 'test2'
+    assert res[1].module == 'test_foo.Bar'
     assert res[1].extra_text == ''
 
 

--- a/spyder_unittest/backend/unittestrunner.py
+++ b/spyder_unittest/backend/unittestrunner.py
@@ -54,14 +54,20 @@ class UnittestRunner(RunnerBase):
         while line_index < len(lines):
             data = self.try_parse_result(lines[line_index])
             if data:
-                name = data[1] + '.' + data[0]
                 if data[2] == 'ok':
                     cat = Category.OK
                 elif data[2] == 'FAIL' or data[2] == 'ERROR':
                     cat = Category.FAIL
                 else:
                     cat = Category.SKIP
-                tr = TestResult(cat, data[2], name, data[3], 0, '')
+                tr = TestResult(
+                    category=cat,
+                    status=data[2],
+                    name=data[0],
+                    module=data[1],
+                    message=data[3],
+                    time=0,
+                    extra_text='')
                 res.append(tr)
                 line_index += 1
                 test_index = -1
@@ -70,9 +76,9 @@ class UnittestRunner(RunnerBase):
             data = self.try_parse_exception_header(lines, line_index)
             if data:
                 line_index = data[0]
-                name = data[2] + '.' + data[1]
-                test_index = next(i for i, tr in enumerate(res)
-                                  if tr.name == name)
+                test_index = next(
+                    i for i, tr in enumerate(res)
+                    if tr.name == data[1] and tr.module == data[2])
 
             data = self.try_parse_footer(lines, line_index)
             if data:

--- a/spyder_unittest/widgets/tests/test_unittestgui.py
+++ b/spyder_unittest/widgets/tests/test_unittestgui.py
@@ -14,13 +14,23 @@ from qtpy.QtCore import Qt
 import pytest
 
 # Local imports
+from spyder_unittest.backend.runnerbase import Category, TestResult
 from spyder_unittest.widgets.configdialog import Config
-from spyder_unittest.widgets.unittestgui import UnitTestWidget
+from spyder_unittest.widgets.unittestgui import (UnitTestDataTree,
+                                                 UnitTestWidget)
 
 try:
     from unittest.mock import Mock
 except ImportError:
     from mock import Mock  # Python 2
+
+
+def test_unittestdatatree_shows_full_name_in_tooltip(qtbot):
+    datatree = UnitTestDataTree()
+    res = TestResult(Category.OK, 'status', 'foo.bar', '', 0, '')
+    datatree.testresults = [res]
+    datatree.populate_tree()
+    assert datatree.topLevelItem(0).data(1, Qt.ToolTipRole) == 'foo.bar'
 
 
 @pytest.mark.parametrize('framework', ['py.test', 'nose'])

--- a/spyder_unittest/widgets/tests/test_unittestgui.py
+++ b/spyder_unittest/widgets/tests/test_unittestgui.py
@@ -25,9 +25,17 @@ except ImportError:
     from mock import Mock  # Python 2
 
 
+def test_unittestdatatree_shows_short_name_in_table(qtbot):
+    datatree = UnitTestDataTree()
+    res = TestResult(Category.OK, 'status', 'bar', 'foo', '', 0, '')
+    datatree.testresults = [res]
+    datatree.populate_tree()
+    assert datatree.topLevelItem(0).data(1, Qt.DisplayRole) == 'bar'
+
+
 def test_unittestdatatree_shows_full_name_in_tooltip(qtbot):
     datatree = UnitTestDataTree()
-    res = TestResult(Category.OK, 'status', 'foo.bar', '', 0, '')
+    res = TestResult(Category.OK, 'status', 'bar', 'foo', '', 0, '')
     datatree.testresults = [res]
     datatree.populate_tree()
     assert datatree.topLevelItem(0).data(1, Qt.ToolTipRole) == 'foo.bar'
@@ -58,10 +66,12 @@ def test_run_tests_and_display_results(qtbot, tmpdir, monkeypatch, framework):
     itemcount = dt.topLevelItemCount()
     assert itemcount == 2
     assert dt.topLevelItem(0).data(0, Qt.DisplayRole) == 'ok'
-    assert dt.topLevelItem(0).data(1, Qt.DisplayRole) == 'test_foo.test_ok'
+    assert dt.topLevelItem(0).data(1, Qt.DisplayRole) == 'test_ok'
+    assert dt.topLevelItem(0).data(1, Qt.ToolTipRole) == 'test_foo.test_ok'
     assert dt.topLevelItem(0).data(2, Qt.DisplayRole) == ''
     assert dt.topLevelItem(1).data(0, Qt.DisplayRole) == 'failure'
-    assert dt.topLevelItem(1).data(1, Qt.DisplayRole) == 'test_foo.test_fail'
+    assert dt.topLevelItem(1).data(1, Qt.DisplayRole) == 'test_fail'
+    assert dt.topLevelItem(1).data(1, Qt.ToolTipRole) == 'test_foo.test_fail'
 
 
 def test_run_tests_using_unittest_and_display_results(qtbot, tmpdir,
@@ -87,12 +97,15 @@ def test_run_tests_using_unittest_and_display_results(qtbot, tmpdir,
         widget.run_tests(config)
 
     MockQMessageBox.assert_not_called()
-    itemcount = widget.datatree.topLevelItemCount()
-    assert itemcount == 2
-    data = lambda i, j: widget.datatree.topLevelItem(i).data(j, Qt.DisplayRole)
-    assert data(0, 0) == 'FAIL'
-    assert data(0, 1) == 'test_foo.MyTest.test_fail'
-    assert data(0, 2) == ''
-    assert data(1, 0) == 'ok'
-    assert data(1, 1) == 'test_foo.MyTest.test_ok'
-    assert data(1, 2) == ''
+    dt = widget.datatree
+    assert dt.topLevelItemCount() == 2
+    assert dt.topLevelItem(0).data(0, Qt.DisplayRole) == 'FAIL'
+    assert dt.topLevelItem(0).data(1, Qt.DisplayRole) == 'test_fail'
+    assert (dt.topLevelItem(0).data(1, Qt.ToolTipRole) ==
+            'test_foo.MyTest.test_fail')
+    assert dt.topLevelItem(0).data(2, Qt.DisplayRole) == ''
+    assert dt.topLevelItem(1).data(0, Qt.DisplayRole) == 'ok'
+    assert dt.topLevelItem(1).data(1, Qt.DisplayRole) == 'test_ok'
+    assert (dt.topLevelItem(1).data(1, Qt.ToolTipRole) ==
+            'test_foo.MyTest.test_ok')
+    assert dt.topLevelItem(1).data(2, Qt.DisplayRole) == ''

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -316,6 +316,7 @@ class UnitTestDataTree(QTreeWidget):
             testcase_item = QTreeWidgetItem(self)
             testcase_item.setData(0, Qt.DisplayRole, testresult.status)
             testcase_item.setData(1, Qt.DisplayRole, testresult.name)
+            testcase_item.setToolTip(1, testresult.name)
             testcase_item.setData(2, Qt.DisplayRole, testresult.message)
             testcase_item.setData(3, Qt.DisplayRole, testresult.time * 1e3)
             color = COLORS[testresult.category]

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -316,7 +316,8 @@ class UnitTestDataTree(QTreeWidget):
             testcase_item = QTreeWidgetItem(self)
             testcase_item.setData(0, Qt.DisplayRole, testresult.status)
             testcase_item.setData(1, Qt.DisplayRole, testresult.name)
-            testcase_item.setToolTip(1, testresult.name)
+            fullname = '{0}.{1}'.format(testresult.module, testresult.name)
+            testcase_item.setToolTip(1, fullname)
             testcase_item.setData(2, Qt.DisplayRole, testresult.message)
             testcase_item.setData(3, Qt.DisplayRole, testresult.time * 1e3)
             color = COLORS[testresult.category]


### PR DESCRIPTION
Instead of displaying the full name for the tests in the widget (e.g. `spyder_unittest.backend.tests.test_frameworkregistry.test_frameworkregistry_when_empty`), which takes up quite a lot of space, display only the last part (`test_frameworkregistry_when_empty`). The user can hover over the name and the full name will appear in a tooltip. Fixes #11.