### PR TITLE
Properly handle test frameworks which are not installed

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -23,8 +23,6 @@ requirements:
 
   run:
     - lxml
-    - nose
-    - pytest
     - python
     - spyder >=3
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def get_package_data(name, extlist):
 
 
 # Requirements
-REQUIREMENTS = ['lxml', 'nose', 'pytest', 'spyder>=3']
+REQUIREMENTS = ['lxml', 'spyder>=3']
 EXTLIST = ['.jpg', '.png', '.json', '.mo', '.ini']
 LIBNAME = 'spyder_unittest'
 

--- a/spyder_unittest/backend/frameworkregistry.py
+++ b/spyder_unittest/backend/frameworkregistry.py
@@ -28,20 +28,21 @@ class FrameworkRegistry():
         """Initialize self."""
         self.frameworks = {}
 
-    def register(self, framework, runner_class):
-        """Register testing framework and its associated runner.
+    def register(self, runner_class):
+        """Register runner class for a testing framework.
 
         Parameters
         ----------
-        framework : str
-            Name of testing framework.
         runner_class : type
             Class used for creating tests runners for the framework.
         """
-        self.frameworks[framework] = runner_class
+        self.frameworks[runner_class.name] = runner_class
 
     def create_runner(self, framework, widget, tempfilename):
         """Create test runner associated to some testing framework.
+
+        This creates an instance of the runner class whose `name` attribute
+        equals `framework`.
 
         Parameters
         ----------

--- a/spyder_unittest/backend/frameworkregistry.py
+++ b/spyder_unittest/backend/frameworkregistry.py
@@ -19,14 +19,14 @@ class FrameworkRegistry():
 
     Attributes
     ----------
-    framework : dict of (str, type)
+    frameworks : dict of (str, type)
         Dictionary mapping names of testing frameworks to the types of the
         associated runners.
     """
 
     def __init__(self):
         """Initialize self."""
-        self.frameworks_dict = {}
+        self.frameworks = {}
 
     def register(self, framework, runner_class):
         """Register testing framework and its associated runner.
@@ -38,7 +38,7 @@ class FrameworkRegistry():
         runner_class : type
             Class used for creating tests runners for the framework.
         """
-        self.frameworks_dict[framework] = runner_class
+        self.frameworks[framework] = runner_class
 
     def create_runner(self, framework, widget, tempfilename):
         """Create test runner associated to some testing framework.
@@ -62,10 +62,5 @@ class FrameworkRegistry():
         KeyError
             Provided testing framework has not been registered.
         """
-        cls = self.frameworks_dict[framework]
+        cls = self.frameworks[framework]
         return cls(widget, tempfilename)
-
-    @property
-    def frameworks(self):
-        """Iterable with names of all frameworks."""
-        return self.frameworks_dict.keys()

--- a/spyder_unittest/backend/noserunner.py
+++ b/spyder_unittest/backend/noserunner.py
@@ -13,6 +13,7 @@ class NoseRunner(RunnerBase):
     """Class for running tests within Nose framework."""
 
     module = 'nose'
+    name = 'nose'
 
     def create_argument_list(self):
         """Create argument list for testing process."""

--- a/spyder_unittest/backend/noserunner.py
+++ b/spyder_unittest/backend/noserunner.py
@@ -12,7 +12,7 @@ from spyder_unittest.backend.runnerbase import RunnerBase
 class NoseRunner(RunnerBase):
     """Class for running tests within Nose framework."""
 
-    executable = 'nosetests'
+    module = 'nose'
 
     def create_argument_list(self):
         """Create argument list for testing process."""

--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -13,6 +13,7 @@ class PyTestRunner(RunnerBase):
     """Class for running tests within py.test framework."""
 
     module = 'pytest'
+    name = 'py.test'
 
     def create_argument_list(self):
         """Create argument list for testing process (dummy)."""

--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -12,7 +12,7 @@ from spyder_unittest.backend.runnerbase import RunnerBase
 class PyTestRunner(RunnerBase):
     """Class for running tests within py.test framework."""
 
-    executable = 'py.test'
+    module = 'pytest'
 
     def create_argument_list(self):
         """Create argument list for testing process (dummy)."""

--- a/spyder_unittest/backend/runnerbase.py
+++ b/spyder_unittest/backend/runnerbase.py
@@ -92,7 +92,8 @@ class RunnerBase(QObject):
         else:
             self.resultfilename = resultfilename
 
-    def is_installed(self):
+    @classmethod
+    def is_installed(cls):
         """
         Check whether test framework is installed.
 
@@ -104,7 +105,7 @@ class RunnerBase(QObject):
         bool
             True if framework is installed, False otherwise.
         """
-        return find_spec_or_loader(self.module) is not None
+        return find_spec_or_loader(cls.module) is not None
 
     def create_argument_list(self):
         """

--- a/spyder_unittest/backend/runnerbase.py
+++ b/spyder_unittest/backend/runnerbase.py
@@ -16,7 +16,7 @@ from qtpy.QtCore import (QObject, QProcess, QProcessEnvironment, QTextCodec,
                          Signal)
 from spyder.config.base import get_translation
 from spyder.py3compat import to_text_string
-from spyder.utils.misc import add_pathlist_to_PYTHONPATH
+from spyder.utils.misc import add_pathlist_to_PYTHONPATH, get_python_executable
 
 try:
     _ = get_translation("unittest", dirname="spyder_unittest")
@@ -49,9 +49,9 @@ class RunnerBase(QObject):
 
     Attributes
     ----------
-    executable : str
-        Name of executable for test framework. This needs to be defined before
-        the user can run tests.
+    module : str
+        Name of Python module for test framework. This needs to be defined
+        before the user can run tests.
     process : QProcess or None
         Process running the unit test suite.
     resultfilename : str
@@ -134,11 +134,8 @@ class RunnerBase(QObject):
                 processEnvironment.insert(envName, envValue)
             self.process.setProcessEnvironment(processEnvironment)
 
-        executable = self.executable
-        p_args = self.create_argument_list()
-
-        if os.name == 'nt':
-            executable += '.exe'
+        executable = get_python_executable()
+        p_args = ['-m', self.module] + self.create_argument_list()
 
         try:
             os.remove(self.resultfilename)

--- a/spyder_unittest/backend/runnerbase.py
+++ b/spyder_unittest/backend/runnerbase.py
@@ -57,6 +57,8 @@ class RunnerBase(QObject):
     module : str
         Name of Python module for test framework. This needs to be defined
         before the user can run tests.
+    name : str
+        Name of test framework, as presented to user.
     process : QProcess or None
         Process running the unit test suite.
     resultfilename : str

--- a/spyder_unittest/backend/runnerbase.py
+++ b/spyder_unittest/backend/runnerbase.py
@@ -19,6 +19,11 @@ from spyder.py3compat import to_text_string
 from spyder.utils.misc import add_pathlist_to_PYTHONPATH, get_python_executable
 
 try:
+    from importlib.util import find_spec as find_spec_or_loader
+except ImportError:  # Python 2
+    from importlib import find_loader as find_spec_or_loader
+
+try:
     _ = get_translation("unittest", dirname="spyder_unittest")
 except KeyError as error:
     import gettext
@@ -84,6 +89,20 @@ class RunnerBase(QObject):
                                                'unittest.results')
         else:
             self.resultfilename = resultfilename
+
+    def is_installed(self):
+        """
+        Check whether test framework is installed.
+
+        This function tests whether self.module is installed, but it does not
+        import it.
+
+        Returns
+        -------
+        bool
+            True if framework is installed, False otherwise.
+        """
+        return find_spec_or_loader(self.module) is not None
 
     def create_argument_list(self):
         """

--- a/spyder_unittest/backend/runnerbase.py
+++ b/spyder_unittest/backend/runnerbase.py
@@ -21,7 +21,7 @@ from spyder.utils.misc import add_pathlist_to_PYTHONPATH, get_python_executable
 try:
     from importlib.util import find_spec as find_spec_or_loader
 except ImportError:  # Python 2
-    from importlib import find_loader as find_spec_or_loader
+    from pkgutil import find_loader as find_spec_or_loader
 
 try:
     _ = get_translation("unittest", dirname="spyder_unittest")

--- a/spyder_unittest/backend/tests/test_frameworkregistry.py
+++ b/spyder_unittest/backend/tests/test_frameworkregistry.py
@@ -13,6 +13,8 @@ from spyder_unittest.backend.frameworkregistry import FrameworkRegistry
 
 
 class MockRunner:
+    name = 'foo'
+
     def __init__(self, *args):
         self.init_args = args
 
@@ -25,7 +27,7 @@ def test_frameworkregistry_when_empty():
 
 def test_frameworkregistry_after_registering():
     reg = FrameworkRegistry()
-    reg.register('foo', MockRunner)
+    reg.register(MockRunner)
     runner = reg.create_runner('foo', None, 'temp.txt')
     assert isinstance(runner, MockRunner)
     assert runner.init_args == (None, 'temp.txt')

--- a/spyder_unittest/backend/tests/test_frameworkregistry.py
+++ b/spyder_unittest/backend/tests/test_frameworkregistry.py
@@ -29,11 +29,3 @@ def test_frameworkregistry_after_registering():
     runner = reg.create_runner('foo', None, 'temp.txt')
     assert isinstance(runner, MockRunner)
     assert runner.init_args == (None, 'temp.txt')
-
-
-def test_frameworkregistry_frameworks():
-    reg = FrameworkRegistry()
-    frameworks = {'spam', 'ham', 'eggs'}
-    for name in frameworks:
-        reg.register(name, object)
-    assert frameworks == set(reg.frameworks)

--- a/spyder_unittest/backend/tests/test_pytestrunner.py
+++ b/spyder_unittest/backend/tests/test_pytestrunner.py
@@ -18,6 +18,10 @@ except ImportError:
     from mock import Mock  # Python 2
 
 
+def test_pytestrunner_is_installed():
+    assert PyTestRunner(None).is_installed()
+
+
 def test_pytestrunner_start(monkeypatch):
     MockQProcess = Mock()
     monkeypatch.setattr('spyder_unittest.backend.runnerbase.QProcess',

--- a/spyder_unittest/backend/tests/test_pytestrunner.py
+++ b/spyder_unittest/backend/tests/test_pytestrunner.py
@@ -5,8 +5,8 @@
 # (see LICENSE.txt for details)
 """Tests for pytestrunner.py"""
 
-# Standard library imports
-import os
+# Third party imports
+from spyder.utils.misc import get_python_executable
 
 # Local imports
 from spyder_unittest.backend.pytestrunner import PyTestRunner
@@ -43,9 +43,8 @@ def test_pytestrunner_start(monkeypatch):
     mock_process.finished.connect.assert_called_once_with(runner.finished)
     mock_process.setProcessEnvironment.assert_called_once_with(
         mock_environment)
-    executable_name = 'py.test.exe' if os.name == 'nt' else 'py.test'
-    mock_process.start.assert_called_once_with(executable_name,
-                                               ['--junit-xml', 'results'])
+    mock_process.start.assert_called_once_with(
+        get_python_executable(), ['-m', 'pytest', '--junit-xml', 'results'])
 
     mock_environment.insert.assert_any_call('VAR', 'VALUE')
     # mock_environment.insert.assert_any_call('PYTHONPATH', 'pythondir:old')

--- a/spyder_unittest/backend/tests/test_runnerbase.py
+++ b/spyder_unittest/backend/tests/test_runnerbase.py
@@ -10,9 +10,10 @@ from spyder_unittest.backend.runnerbase import Category, RunnerBase
 
 
 def test_runnerbase_with_nonexisting_module():
-    runner = RunnerBase(None)
-    runner.module = 'nonexisiting'
-    assert not runner.is_installed()
+    class FooRunner(RunnerBase):
+        module = 'nonexisiting'
+
+    assert not FooRunner.is_installed()
 
 
 def test_runnerbase_load_data(tmpdir):

--- a/spyder_unittest/backend/tests/test_runnerbase.py
+++ b/spyder_unittest/backend/tests/test_runnerbase.py
@@ -9,7 +9,13 @@
 from spyder_unittest.backend.runnerbase import Category, RunnerBase
 
 
-def test_baserunner_load_data(tmpdir):
+def test_runnerbase_with_nonexisting_module():
+    runner = RunnerBase(None)
+    runner.module = 'nonexisiting'
+    assert not runner.is_installed()
+
+
+def test_runnerbase_load_data(tmpdir):
     result_file = tmpdir.join('results')
     result_txt = """<?xml version="1.0" encoding="utf-8"?>
 <testsuite errors="0" failures="1" name="pytest" skips="1" tests="3" time="0.1">
@@ -50,7 +56,7 @@ def test_baserunner_load_data(tmpdir):
     assert results[2].extra_text == 'text2'
 
 
-def test_baserunner_load_data_failing_test_with_stdout(tmpdir):
+def test_runnerbase_load_data_failing_test_with_stdout(tmpdir):
     result_file = tmpdir.join('results')
     result_txt = """<?xml version="1.0" encoding="utf-8"?>
 <testsuite errors="0" failures="1" name="pytest" skips="0" tests="1" time="0.1">
@@ -65,7 +71,7 @@ def test_baserunner_load_data_failing_test_with_stdout(tmpdir):
         'text\n\n' + '----- Captured stdout -----\n' + 'stdout text')
 
 
-def test_baserunner_load_data_passing_test_with_stdout(tmpdir):
+def test_runnerbase_load_data_passing_test_with_stdout(tmpdir):
     result_file = tmpdir.join('results')
     result_txt = """<?xml version="1.0" encoding="utf-8"?>
 <testsuite errors="0" failures="0" name="pytest" skips="0" tests="1" time="0.1">

--- a/spyder_unittest/backend/unittestrunner.py
+++ b/spyder_unittest/backend/unittestrunner.py
@@ -19,11 +19,11 @@ from spyder_unittest.backend.runnerbase import Category, RunnerBase, TestResult
 class UnittestRunner(RunnerBase):
     """Class for running tests with unittest module in standard library."""
 
-    executable = 'python'
+    module = 'unittest'
 
     def create_argument_list(self):
         """Create argument list for testing process."""
-        return ['-m', 'unittest', 'discover', '-v']
+        return ['discover', '-v']
 
     def finished(self):
         """

--- a/spyder_unittest/backend/unittestrunner.py
+++ b/spyder_unittest/backend/unittestrunner.py
@@ -20,6 +20,7 @@ class UnittestRunner(RunnerBase):
     """Class for running tests with unittest module in standard library."""
 
     module = 'unittest'
+    name = 'unittest'
 
     def create_argument_list(self):
         """Create argument list for testing process."""

--- a/spyder_unittest/widgets/configdialog.py
+++ b/spyder_unittest/widgets/configdialog.py
@@ -65,8 +65,12 @@ class ConfigDialog(QDialog):
         framework_label = QLabel(_('Test framework'))
         framework_layout.addWidget(framework_label)
         self.framework_combobox = QComboBox(self)
-        for framework in sorted(frameworks):
-            self.framework_combobox.addItem(framework)
+        for name, runner in sorted(frameworks.items()):
+            if runner.is_installed():
+                label = name
+            else:
+                label = '{} ({})'.format(name, _('not available'))
+            self.framework_combobox.addItem(label)
         framework_layout.addWidget(self.framework_combobox)
         layout.addLayout(framework_layout)
 

--- a/spyder_unittest/widgets/configdialog.py
+++ b/spyder_unittest/widgets/configdialog.py
@@ -64,7 +64,7 @@ class ConfigDialog(QDialog):
         framework_label = QLabel(_('Test framework'))
         framework_layout.addWidget(framework_label)
         self.framework_combobox = QComboBox(self)
-        for framework in frameworks:
+        for framework in sorted(frameworks):
             self.framework_combobox.addItem(framework)
         framework_layout.addWidget(self.framework_combobox)
         layout.addLayout(framework_layout)

--- a/spyder_unittest/widgets/configdialog.py
+++ b/spyder_unittest/widgets/configdialog.py
@@ -64,13 +64,17 @@ class ConfigDialog(QDialog):
         framework_layout = QHBoxLayout()
         framework_label = QLabel(_('Test framework'))
         framework_layout.addWidget(framework_label)
+
         self.framework_combobox = QComboBox(self)
-        for name, runner in sorted(frameworks.items()):
-            if runner.is_installed():
+        for ix, (name, runner) in enumerate(sorted(frameworks.items())):
+            installed = runner.is_installed()
+            if installed:
                 label = name
             else:
                 label = '{} ({})'.format(name, _('not available'))
             self.framework_combobox.addItem(label)
+            self.framework_combobox.model().item(ix).setEnabled(installed)
+
         framework_layout.addWidget(self.framework_combobox)
         layout.addLayout(framework_layout)
 

--- a/spyder_unittest/widgets/configdialog.py
+++ b/spyder_unittest/widgets/configdialog.py
@@ -50,8 +50,9 @@ class ConfigDialog(QDialog):
 
         Parameters
         ----------
-        frameworks : iterable of str
-            Names of all supported frameworks
+        frameworks : dict of (str, type)
+            Names of all supported frameworks with their associated class
+            (assumed to be a subclass of RunnerBase)
         config : Config
             Initial configuration
         parent : QWidget

--- a/spyder_unittest/widgets/tests/test_configdialog.py
+++ b/spyder_unittest/widgets/tests/test_configdialog.py
@@ -56,6 +56,14 @@ def test_configdialog_indicates_unvailable_frameworks(qtbot):
         0) == 'spam (not available)'
 
 
+def test_configdialog_disables_unavailable_frameworks(qtbot):
+    configdialog = ConfigDialog(frameworks, default_config())
+    model = configdialog.framework_combobox.model()
+    assert model.item(0).isEnabled()  # eggs
+    assert model.item(1).isEnabled()  # ham
+    assert not model.item(2).isEnabled()  # spam
+
+
 def test_configdialog_sets_initial_config(qtbot):
     config = default_config()
     configdialog = ConfigDialog(frameworks, config)

--- a/spyder_unittest/widgets/tests/test_configdialog.py
+++ b/spyder_unittest/widgets/tests/test_configdialog.py
@@ -18,13 +18,22 @@ from spyder_unittest.widgets.configdialog import Config, ConfigDialog
 class SpamRunner:
     name = 'spam'
 
+    def is_installed():
+        return False
+
 
 class HamRunner:
     name = 'ham'
 
+    def is_installed():
+        return True
+
 
 class EggsRunner:
     name = 'eggs'
+
+    def is_installed():
+        return True
 
 
 frameworks = {r.name: r for r in [SpamRunner, HamRunner, EggsRunner]}
@@ -35,11 +44,16 @@ def default_config():
 
 
 def test_configdialog_uses_frameworks(qtbot):
-    framework_names = sorted(frameworks)
-    configdialog = ConfigDialog(frameworks, default_config())
-    assert configdialog.framework_combobox.count() == len(frameworks)
-    for i, framework in enumerate(framework_names):
-        assert configdialog.framework_combobox.itemText(i) == framework
+    configdialog = ConfigDialog({'eggs': EggsRunner}, default_config())
+    assert configdialog.framework_combobox.count() == 1
+    assert configdialog.framework_combobox.itemText(0) == 'eggs'
+
+
+def test_configdialog_indicates_unvailable_frameworks(qtbot):
+    configdialog = ConfigDialog({'spam': SpamRunner}, default_config())
+    assert configdialog.framework_combobox.count() == 1
+    assert configdialog.framework_combobox.itemText(
+        0) == 'spam (not available)'
 
 
 def test_configdialog_sets_initial_config(qtbot):

--- a/spyder_unittest/widgets/tests/test_configdialog.py
+++ b/spyder_unittest/widgets/tests/test_configdialog.py
@@ -14,7 +14,20 @@ from qtpy.QtWidgets import QDialogButtonBox
 # Local imports
 from spyder_unittest.widgets.configdialog import Config, ConfigDialog
 
-frameworks = {'nose': object, 'py.test': object}
+
+class SpamRunner:
+    name = 'spam'
+
+
+class HamRunner:
+    name = 'ham'
+
+
+class EggsRunner:
+    name = 'eggs'
+
+
+frameworks = {r.name: r for r in [SpamRunner, HamRunner, EggsRunner]}
 
 
 def default_config():
@@ -22,7 +35,6 @@ def default_config():
 
 
 def test_configdialog_uses_frameworks(qtbot):
-    frameworks = {'spam': object, 'ham': object, 'eggs': object}
     framework_names = sorted(frameworks)
     configdialog = ConfigDialog(frameworks, default_config())
     assert configdialog.framework_combobox.count() == len(frameworks)
@@ -36,11 +48,11 @@ def test_configdialog_sets_initial_config(qtbot):
     assert configdialog.get_config() == config
 
 
-def test_configdialog_click_pytest(qtbot):
+def test_configdialog_click_ham(qtbot):
     configdialog = ConfigDialog(frameworks, default_config())
     qtbot.addWidget(configdialog)
     configdialog.framework_combobox.setCurrentIndex(1)
-    assert configdialog.get_config().framework == 'py.test'
+    assert configdialog.get_config().framework == 'ham'
 
 
 def test_configdialog_ok_initially_disabled(qtbot):
@@ -50,7 +62,7 @@ def test_configdialog_ok_initially_disabled(qtbot):
 
 
 def test_configdialog_ok_setting_framework_initially_enables_ok(qtbot):
-    config = Config(framework='py.test', wdir=os.getcwd())
+    config = Config(framework='eggs', wdir=os.getcwd())
     configdialog = ConfigDialog(frameworks, config)
     qtbot.addWidget(configdialog)
     assert configdialog.buttons.button(QDialogButtonBox.Ok).isEnabled()

--- a/spyder_unittest/widgets/tests/test_configdialog.py
+++ b/spyder_unittest/widgets/tests/test_configdialog.py
@@ -18,21 +18,24 @@ from spyder_unittest.widgets.configdialog import Config, ConfigDialog
 class SpamRunner:
     name = 'spam'
 
-    def is_installed():
+    @classmethod
+    def is_installed(cls):
         return False
 
 
 class HamRunner:
     name = 'ham'
 
-    def is_installed():
+    @classmethod
+    def is_installed(cls):
         return True
 
 
 class EggsRunner:
     name = 'eggs'
 
-    def is_installed():
+    @classmethod
+    def is_installed(cls):
         return True
 
 

--- a/spyder_unittest/widgets/tests/test_configdialog.py
+++ b/spyder_unittest/widgets/tests/test_configdialog.py
@@ -14,7 +14,7 @@ from qtpy.QtWidgets import QDialogButtonBox
 # Local imports
 from spyder_unittest.widgets.configdialog import Config, ConfigDialog
 
-frameworks = ['nose', 'py.test']
+frameworks = {'nose': object, 'py.test': object}
 
 
 def default_config():
@@ -22,10 +22,11 @@ def default_config():
 
 
 def test_configdialog_uses_frameworks(qtbot):
-    frameworks = ['spam', 'ham', 'eggs']
+    frameworks = {'spam': object, 'ham': object, 'eggs': object}
+    framework_names = sorted(frameworks)
     configdialog = ConfigDialog(frameworks, default_config())
     assert configdialog.framework_combobox.count() == len(frameworks)
-    for i, framework in enumerate(frameworks):
+    for i, framework in enumerate(framework_names):
         assert configdialog.framework_combobox.itemText(i) == framework
 
 

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -177,7 +177,7 @@ class UnitTestWidget(QWidget):
             oldconfig = self.config
         else:
             oldconfig = Config(wdir=self.default_wdir)
-        frameworks = sorted(self.framework_registry.frameworks)
+        frameworks = self.framework_registry.frameworks
         config = ask_for_config(frameworks, oldconfig)
         if config:
             self.config = config

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -47,11 +47,7 @@ COLORS = {
 }
 
 # Supported testing framework
-FRAMEWORKS = {
-    'nose': NoseRunner,
-    'py.test': PyTestRunner,
-    'unittest': UnittestRunner
-}
+FRAMEWORKS = {NoseRunner, PyTestRunner, UnittestRunner}
 
 
 def is_unittesting_installed():
@@ -102,8 +98,8 @@ class UnitTestWidget(QWidget):
         self.datatree = UnitTestDataTree(self)
 
         self.framework_registry = FrameworkRegistry()
-        for (name, runner) in FRAMEWORKS.items():
-            self.framework_registry.register(name, runner)
+        for runner in FRAMEWORKS:
+            self.framework_registry.register(runner)
 
         self.start_button = create_toolbutton(self, text_beside_icon=True)
         self.set_running_state(False)


### PR DESCRIPTION
This PR checks whether all the testing frameworks (nose, py.test, unittest) are installed. If not, then this is indicated when the user is asks to select a testing framework, and the user is prevented from selecting frameworks that are not available. Fixes #15 .

The PR also runs the tests by calling the Python interpreter directly (e.g., for py.test, it runs `python -m pytest` instead of the `py.test` executable), thus partially addressing #65 . It drops the dependencies on nose and py.test, because the plugin can now be used without either of them installed: it can still use unittest which is part of the standard library.