### PR TITLE
Load and save configuration for tests

### DIFF
--- a/spyder_unittest/widgets/tests/test_unittestgui.py
+++ b/spyder_unittest/widgets/tests/test_unittestgui.py
@@ -25,6 +25,25 @@ except ImportError:
     from mock import Mock  # Python 2
 
 
+def test_unittestgui_set_config_emits_newconfig(qtbot):
+    widget = UnitTestWidget(None)
+    qtbot.addWidget(widget)
+    config = Config(wdir=os.getcwd(), framework='unittest')
+    with qtbot.waitSignal(widget.sig_newconfig) as blocker:
+        widget.config = config
+    assert blocker.args == [config]
+    assert widget.config == config
+
+
+def test_unittestgui_set_config_does_not_emit_when_invalid(qtbot):
+    widget = UnitTestWidget(None)
+    qtbot.addWidget(widget)
+    config = Config(wdir=os.getcwd(), framework=None)
+    with qtbot.assertNotEmitted(widget.sig_newconfig):
+        widget.config = config
+    assert widget.config == config
+
+
 def test_unittestdatatree_shows_short_name_in_table(qtbot):
     datatree = UnitTestDataTree()
     res = TestResult(Category.OK, 'status', 'bar', 'foo', '', 0, '')

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -78,11 +78,14 @@ class UnitTestWidget(QWidget):
     Signals
     -------
     sig_finished: Emitted when plugin finishes processing tests.
+    sig_newconfig(Config): Emitted when test config is changed.
+        Argument is new config, which is always valid.
     """
 
     VERSION = '0.0.1'
 
     sig_finished = Signal()
+    sig_newconfig = Signal(Config)
 
     def __init__(self, parent, options_button=None, options_menu=None):
         """Unit testing widget."""
@@ -138,6 +141,18 @@ class UnitTestWidget(QWidget):
                 widget.setDisabled(True)
         else:
             pass  # self.show_data()
+
+    @property
+    def config(self):
+        """Return current test configuration."""
+        return self._config
+
+    @config.setter
+    def config(self, new_config):
+        """Set test configuration and emit sig_newconfig if valid."""
+        self._config = new_config
+        if self.config_is_valid():
+            self.sig_newconfig.emit(new_config)
 
     def create_actions(self):
         """Create the actions for the unittest widget."""

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -63,8 +63,8 @@ class UnitTestWidget(QWidget):
 
     Attributes
     ----------
-    config : Config
-        Configuration for running tests.
+    config : Config or None
+        Configuration for running tests, or `None` if not set.
     default_wdir : str
         Default choice of working directory.
     framework_registry : FrameworkRegistry
@@ -154,6 +154,10 @@ class UnitTestWidget(QWidget):
         if self.config_is_valid():
             self.sig_newconfig.emit(new_config)
 
+    def set_config_without_emit(self, new_config):
+        """Set test configuration but do not emit any signal."""
+        self._config = new_config
+
     def create_actions(self):
         """Create the actions for the unittest widget."""
         self.config_action = create_action(
@@ -201,10 +205,18 @@ class UnitTestWidget(QWidget):
         if config:
             self.config = config
 
-    def config_is_valid(self):
-        """Return whether configuration for running tests is valid."""
-        return (self.config and self.config.framework and
-                osp.isdir(self.config.wdir))
+    def config_is_valid(self, config=None):
+        """
+        Return whether configuration for running tests is valid.
+
+        Parameters
+        ----------
+        config : Config or None
+            configuration for unit tests. If None, use `self.config`.
+        """
+        if config is None:
+            config = self.config
+        return (config and config.framework and osp.isdir(config.wdir))
 
     def maybe_configure_and_start(self):
         """


### PR DESCRIPTION
The configuration is saved in the project preferences (because it is probably specific to a particular project), so that the user does not have to specify the testing framework again in subsequent sessions. If no project is opened, the configuration is not saved. Fixes #43.