### PR TITLE
Add unit tests for plugin

### DIFF
--- a/spyder_unittest/tests/test_unittestplugin.py
+++ b/spyder_unittest/tests/test_unittestplugin.py
@@ -6,11 +6,11 @@
 """Tests for unittestplugin.py"""
 
 # Third party imports
-from qtpy.QtWidgets import QWidget
 import pytest
 
 # Local imports
 from spyder_unittest.unittestplugin import UnitTestPlugin
+from spyder_unittest.widgets.configdialog import Config
 
 try:
     from unittest.mock import Mock
@@ -24,12 +24,100 @@ def plugin(qtbot):
     res = UnitTestPlugin(None)
     qtbot.addWidget(res)
     res.main = Mock()
+    res.main.get_spyder_pythonpath = lambda: 'fakepythonpath'
     res.main.run_menu_actions = [42]
     res.main.editor.pythonfile_dependent_actions = [42]
+    res.main.projects.get_active_project_path = lambda: None
     res.register_plugin()
     return res
 
 
-def test_initialization(plugin):
-    """Check that plugin initialization does not yield an error."""
+def test_plugin_initialization(plugin):
     plugin.show()
+    assert len(plugin.main.run_menu_actions) == 2
+    assert plugin.main.run_menu_actions[1].text() == 'Run unit tests'
+
+
+def test_plugin_pythonpath(plugin):
+    # Test signal/slot connection
+    plugin.main.sig_pythonpath_changed.connect.assert_called_with(
+        plugin.update_pythonpath)
+
+    # Test pythonpath is set to path provided by Spyder
+    assert plugin.unittestwidget.pythonpath == 'fakepythonpath'
+
+    # Test that change in path propagates
+    plugin.main.get_spyder_pythonpath = lambda: 'anotherpath'
+    plugin.update_pythonpath()
+    assert plugin.unittestwidget.pythonpath == 'anotherpath'
+
+
+def test_plugin_wdir(plugin, monkeypatch, tmpdir):
+    # Test signal/slot connections
+    plugin.main.workingdirectory.set_explorer_cwd.connect.assert_called_with(
+        plugin.update_default_wdir)
+    plugin.main.projects.sig_project_created.connect.assert_called_with(
+        plugin.handle_project_change)
+    plugin.main.projects.sig_project_loaded.connect.assert_called_with(
+        plugin.handle_project_change)
+    plugin.main.projects.sig_project_closed.connect.assert_called_with(
+        plugin.handle_project_change)
+
+    # Test default_wdir is set to current working dir
+    monkeypatch.setattr('spyder_unittest.unittestplugin.getcwd',
+                        lambda: 'fakecwd')
+    plugin.update_default_wdir()
+    assert plugin.unittestwidget.default_wdir == 'fakecwd'
+
+    # Test after opening project, default_wdir is set to project dir
+    project = Mock()
+    project.CONF = {}
+    project.root_path = str(tmpdir)
+    plugin.main.projects.get_active_project = lambda: project
+    plugin.main.projects.get_active_project_path = lambda: project.root_path
+    plugin.handle_project_change()
+    assert plugin.unittestwidget.default_wdir == str(tmpdir)
+
+    # Test after closing project, default_wdir is set back to cwd
+    plugin.main.projects.get_active_project = lambda: None
+    plugin.main.projects.get_active_project_path = lambda: None
+    plugin.handle_project_change()
+    assert plugin.unittestwidget.default_wdir == 'fakecwd'
+
+
+def test_plugin_config(plugin, tmpdir, qtbot):
+    # Test config file does not exist and config is empty
+    config_file_path = tmpdir.join('.spyproject', 'unittest.ini')
+    assert not config_file_path.check()
+    assert plugin.unittestwidget.config is None
+
+    # Open project
+    project = Mock()
+    project.CONF = {}
+    project.root_path = str(tmpdir)
+    plugin.main.projects.get_active_project = lambda: project
+    plugin.main.projects.get_active_project_path = lambda: project.root_path
+    plugin.handle_project_change()
+
+    # Test config file does exist but config is empty
+    assert config_file_path.check()
+    assert 'framework = ' in config_file_path.read().splitlines()
+    assert plugin.unittestwidget.config is None
+
+    # Set config and test that this is recorded in config file
+    config = Config(framework='ham', wdir=str(tmpdir))
+    with qtbot.waitSignal(plugin.unittestwidget.sig_newconfig):
+        plugin.unittestwidget.config = config
+    assert 'framework = ham' in config_file_path.read().splitlines()
+
+    # Close project and test that config is empty
+    plugin.main.projects.get_active_project = lambda: None
+    plugin.main.projects.get_active_project_path = lambda: None
+    plugin.handle_project_change()
+    assert plugin.unittestwidget.config is None
+
+    # Re-open project and test that config is correctly read    
+    plugin.main.projects.get_active_project = lambda: project
+    plugin.main.projects.get_active_project_path = lambda: project.root_path
+    plugin.handle_project_change()
+    assert plugin.unittestwidget.config == config

--- a/spyder_unittest/tests/test_unittestplugin.py
+++ b/spyder_unittest/tests/test_unittestplugin.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2017 Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+"""Tests for unittestplugin.py"""
+
+# Third party imports
+from qtpy.QtWidgets import QWidget
+import pytest
+
+# Local imports
+from spyder_unittest.unittestplugin import UnitTestPlugin
+
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock  # Python 2
+
+
+@pytest.fixture
+def plugin(qtbot):
+    """Set up the unittest plugin."""
+    res = UnitTestPlugin(None)
+    qtbot.addWidget(res)
+    res.main = Mock()
+    res.main.run_menu_actions = [42]
+    res.main.editor.pythonfile_dependent_actions = [42]
+    res.register_plugin()
+    return res
+
+
+def test_initialization(plugin):
+    """Check that plugin initialization does not yield an error."""
+    plugin.show()

--- a/spyder_unittest/unittestplugin.py
+++ b/spyder_unittest/unittestplugin.py
@@ -120,8 +120,8 @@ class UnitTestPlugin(SpyderPluginWidget):
             project.CONF[self.CONF_SECTION] = project_conf
 
         new_config = Config(
-            framework=project_conf[self.CONF_SECTION]['framework'],
-            wdir=project_conf[self.CONF_SECTION]['wdir'])
+            framework=project_conf.get(self.CONF_SECTION, 'framework'),
+            wdir=project_conf.get(self.CONF_SECTION, 'wdir'))
         if not self.unittestwidget.config_is_valid(new_config):
             new_config = None
         self.unittestwidget.set_config_without_emit(new_config)
@@ -136,8 +136,8 @@ class UnitTestPlugin(SpyderPluginWidget):
         if not project:
             return
         project_conf = project.CONF[self.CONF_SECTION]
-        project_conf[self.CONF_SECTION]['framework'] = test_config.framework
-        project_conf[self.CONF_SECTION]['wdir'] = test_config.wdir
+        project_conf.set(self.CONF_SECTION, 'framework', test_config.framework)
+        project_conf.set(self.CONF_SECTION, 'wdir', test_config.wdir)
 
 # ----- SpyderPluginWidget API --------------------------------------------
 

--- a/spyder_unittest/unittestplugin.py
+++ b/spyder_unittest/unittestplugin.py
@@ -28,8 +28,13 @@ class UnitTestPlugin(SpyderPluginWidget):
     CONF_DEFAULTS = [(CONF_SECTION, {'framework': '', 'wdir': ''})]
     CONF_VERSION = '0.1.0'
 
-    def __init__(self, parent=None):
-        """Initialize plugin and corresponding widget."""
+    def __init__(self, parent):
+        """
+        Initialize plugin and corresponding widget.
+
+        The part of the initialization that depends on `parent` is done in
+        `self.register_plugin()`.
+        """
         SpyderPluginWidget.__init__(self, parent)
         self.main = parent  # Spyder 3 compatibility
 
@@ -45,21 +50,6 @@ class UnitTestPlugin(SpyderPluginWidget):
         else:
             # Works with Spyder 3.x
             self.unittestwidget = UnitTestWidget(self.main)
-
-        self.update_pythonpath()
-        self.update_default_wdir()
-
-        # Connect to relevant signals
-        self.main.sig_pythonpath_changed.connect(self.update_pythonpath)
-        self.main.workingdirectory.set_explorer_cwd.connect(
-            self.update_default_wdir)
-        self.main.projects.sig_project_created.connect(
-            self.handle_project_change)
-        self.main.projects.sig_project_loaded.connect(
-            self.handle_project_change)
-        self.main.projects.sig_project_closed.connect(
-            self.handle_project_change)
-        self.unittestwidget.sig_newconfig.connect(self.save_config)
 
         # Add unit test widget in dockwindow
         layout = QVBoxLayout()
@@ -174,8 +164,26 @@ class UnitTestPlugin(SpyderPluginWidget):
 
     def register_plugin(self):
         """Register plugin in Spyder's main window."""
+        # Get information from Spyder proper into plugin
+        self.update_pythonpath()
+        self.update_default_wdir()
+
+        # Connect to relevant signals
+        self.main.sig_pythonpath_changed.connect(self.update_pythonpath)
+        self.main.workingdirectory.set_explorer_cwd.connect(
+            self.update_default_wdir)
+        self.main.projects.sig_project_created.connect(
+            self.handle_project_change)
+        self.main.projects.sig_project_loaded.connect(
+            self.handle_project_change)
+        self.main.projects.sig_project_closed.connect(
+            self.handle_project_change)
+        self.unittestwidget.sig_newconfig.connect(self.save_config)
+
+        # Add plugin as dockwidget to main window
         self.main.add_dockwidget(self)
 
+        # Create action and add it to Spyder's menu
         unittesting_act = create_action(
             self,
             _("Run unit tests"),


### PR DESCRIPTION
Add unit tests for `UnitTestPlugin` (so the integration with Spyder proper is not tested). Thanks for @rlaverde for giving me an example of how to do this at spyder-ide/spyder-reports#15 .

Fixes #89 .