### PR TITLE
Abbreviate module names when displaying test names

### DIFF
--- a/spyder_unittest/backend/abbreviator.py
+++ b/spyder_unittest/backend/abbreviator.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2017 Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+"""Class for abbreviating test names."""
+
+
+class Abbreviator:
+    """
+    Abbreviates names so that abbreviation identifies name uniquely.
+
+    The abbreviation is the smallest prefix not shared by other names in a
+    given list.
+    """
+
+    def __init__(self, names=[]):
+        """
+        Constructor.
+
+        Arguments
+        ---------
+        names : list of str
+            list of words which needs to be abbreviated.
+        """
+        self.dic = {}
+        for name in names:
+            self.add(name)
+
+    def add(self, name):
+        """
+        Add name to list of names to be abbreviated.
+
+        Arguments
+        ---------
+        name : str
+        """
+        len_abbrev = 1
+        for other in self.dic:
+            if name[:len_abbrev] == other[:len_abbrev]:
+                assert name != other
+                while (name[:len_abbrev] == other[:len_abbrev]
+                       and len_abbrev < len(name) and len_abbrev < len(other)):
+                    len_abbrev += 1
+                if len_abbrev == len(name):
+                    self.dic[other] = other[:len_abbrev + 1]
+                elif len_abbrev == len(other):
+                    self.dic[other] = other
+                    len_abbrev += 1
+                else:
+                    self.dic[other] = other[:len_abbrev]
+        self.dic[name] = name[:len_abbrev]
+
+    def abbreviate(self, name):
+        """Return abbreviation of name."""
+        return self.dic[name]

--- a/spyder_unittest/backend/abbreviator.py
+++ b/spyder_unittest/backend/abbreviator.py
@@ -63,7 +63,8 @@ class Abbreviator:
                     self.dic[other][0] = other
                     len_abbrev += 1
                 else:
-                    self.dic[other][0] = other[:len_abbrev]
+                    if len(self.dic[other][0]) < len_abbrev:
+                        self.dic[other][0] = other[:len_abbrev]
         else:
             self.dic[start] = [start[:len_abbrev], Abbreviator()]
         if rest:

--- a/spyder_unittest/backend/tests/test_abbreviator.py
+++ b/spyder_unittest/backend/tests/test_abbreviator.py
@@ -34,6 +34,12 @@ def test_abbreviator_with_second_word_prefix_of_first():
     assert abb.abbreviate('hameggs') == 'hame'
     assert abb.abbreviate('ham') == 'ham'
 
+def test_abbreviator_with_three_words():
+    abb = Abbreviator(['hamegg', 'hameggs', 'hall'])
+    assert abb.abbreviate('hamegg') == 'hamegg'
+    assert abb.abbreviate('hameggs') == 'hameggs'
+    assert abb.abbreviate('hall') == 'hal'
+
 def test_abbreviator_with_multilevel():
     abb = Abbreviator(['ham.eggs', 'ham.spam', 'eggs.ham', 'eggs.hamspam'])
     assert abb.abbreviate('ham.eggs') == 'h.e'

--- a/spyder_unittest/backend/tests/test_abbreviator.py
+++ b/spyder_unittest/backend/tests/test_abbreviator.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2017 Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+"""Tests for abbreviator.py"""
+
+# Local imports
+from spyder_unittest.backend.abbreviator import Abbreviator
+
+
+def test_abbreviator_with_one_word():
+    abb = Abbreviator()
+    abb.add('ham')
+    assert abb.abbreviate('ham') == 'h'
+
+def test_abbreviator_without_common_prefix():
+    abb = Abbreviator(['ham', 'spam'])
+    assert abb.abbreviate('ham') == 'h'
+    assert abb.abbreviate('spam') == 's'
+
+def test_abbreviator_with_prefix():
+    abb = Abbreviator(['test_ham', 'test_spam'])
+    assert abb.abbreviate('test_ham') == 'test_h'
+    assert abb.abbreviate('test_spam') == 'test_s'
+
+def test_abbreviator_with_first_word_prefix_of_second():
+    abb = Abbreviator(['ham', 'hameggs'])
+    assert abb.abbreviate('ham') == 'ham'
+    assert abb.abbreviate('hameggs') == 'hame'
+
+def test_abbreviator_with_second_word_prefix_of_first():
+    abb = Abbreviator(['hameggs', 'ham'])
+    assert abb.abbreviate('hameggs') == 'hame'
+    assert abb.abbreviate('ham') == 'ham'

--- a/spyder_unittest/backend/tests/test_abbreviator.py
+++ b/spyder_unittest/backend/tests/test_abbreviator.py
@@ -33,3 +33,10 @@ def test_abbreviator_with_second_word_prefix_of_first():
     abb = Abbreviator(['hameggs', 'ham'])
     assert abb.abbreviate('hameggs') == 'hame'
     assert abb.abbreviate('ham') == 'ham'
+
+def test_abbreviator_with_multilevel():
+    abb = Abbreviator(['ham.eggs', 'ham.spam', 'eggs.ham', 'eggs.hamspam'])
+    assert abb.abbreviate('ham.eggs') == 'h.e'
+    assert abb.abbreviate('ham.spam') == 'h.s'
+    assert abb.abbreviate('eggs.ham') == 'e.ham'
+    assert abb.abbreviate('eggs.hamspam') == 'e.hams'

--- a/spyder_unittest/backend/tests/test_jsonstream.py
+++ b/spyder_unittest/backend/tests/test_jsonstream.py
@@ -62,7 +62,7 @@ def test_jsonstreamreader_with_partial_frames():
     assert reader.consume(txt[-2:]) == [2]
 
 
-def test_isonsteamreader_writer_integration():
+def test_jsonsteamreader_writer_integration():
     stream = StringIO()
     writer = JSONStreamWriter(stream)
     reader = JSONStreamReader()

--- a/spyder_unittest/backend/tests/test_pytestrunner.py
+++ b/spyder_unittest/backend/tests/test_pytestrunner.py
@@ -109,13 +109,13 @@ def test_pytestrunner_process_output_with_collected(qtbot):
 
 def test_pytestrunner_process_output_with_starttest(qtbot):
     runner = PyTestRunner(None)
-    output = [{'event': 'starttest', 'nodeid': 'spam.py::ham'},
-              {'event': 'starttest', 'nodeid': 'eggs.py::bacon'}]
+    output = [{'event': 'starttest', 'nodeid': 'ham/spam.py::ham'},
+              {'event': 'starttest', 'nodeid': 'ham/eggs.py::bacon'}]
     with qtbot.waitSignal(runner.sig_starttest) as blocker:
         runner.process_output(output)
     expected = [
-        TestDetails(name='ham', module='spam'),
-        TestDetails(name='bacon', module='eggs')
+        TestDetails(name='ham', module='ham.spam'),
+        TestDetails(name='bacon', module='ham.eggs')
     ]
     assert blocker.args == [expected]
 

--- a/spyder_unittest/widgets/tests/test_datatree.py
+++ b/spyder_unittest/widgets/tests/test_datatree.py
@@ -22,12 +22,12 @@ def test_testdatamodel_using_qtmodeltester(qtmodeltester):
     qtmodeltester.check(model)
 
 
-def test_testdatamodel_shows_short_name_in_table(qtbot):
+def test_testdatamodel_shows_abbreviated_name_in_table(qtbot):
     model = TestDataModel()
     res = TestResult(Category.OK, 'status', 'bar', 'foo', '', 0, '')
     model.testresults = [res]
     index = model.index(0, 1)
-    assert model.data(index, Qt.DisplayRole) == 'bar'
+    assert model.data(index, Qt.DisplayRole) == 'f.bar'
 
 
 def test_testdatamodel_shows_full_name_in_tooltip(qtbot):

--- a/spyder_unittest/widgets/tests/test_unittestgui.py
+++ b/spyder_unittest/widgets/tests/test_unittestgui.py
@@ -115,11 +115,11 @@ def test_run_tests_and_display_results(qtbot, tmpdir, monkeypatch, framework):
     model = widget.testdatamodel
     assert model.rowCount() == 2
     assert model.index(0, 0).data(Qt.DisplayRole) == 'ok'
-    assert model.index(0, 1).data(Qt.DisplayRole) == 'test_ok'
+    assert model.index(0, 1).data(Qt.DisplayRole) == 't.test_ok'
     assert model.index(0, 1).data(Qt.ToolTipRole) == 'test_foo.test_ok'
     assert model.index(0, 2).data(Qt.DisplayRole) == ''
     assert model.index(1, 0).data(Qt.DisplayRole) == 'failure'
-    assert model.index(1, 1).data(Qt.DisplayRole) == 'test_fail'
+    assert model.index(1, 1).data(Qt.DisplayRole) == 't.test_fail'
     assert model.index(1, 1).data(Qt.ToolTipRole) == 'test_foo.test_fail'
 
 
@@ -149,10 +149,10 @@ def test_run_tests_using_unittest_and_display_results(qtbot, tmpdir,
     model = widget.testdatamodel
     assert model.rowCount() == 2
     assert model.index(0, 0).data(Qt.DisplayRole) == 'FAIL'
-    assert model.index(0, 1).data(Qt.DisplayRole) == 'test_fail'
+    assert model.index(0, 1).data(Qt.DisplayRole) == 't.M.test_fail'
     assert model.index(0, 1).data(Qt.ToolTipRole) == 'test_foo.MyTest.test_fail'
     assert model.index(0, 2).data(Qt.DisplayRole) == ''
     assert model.index(1, 0).data(Qt.DisplayRole) == 'ok'
-    assert model.index(1, 1).data(Qt.DisplayRole) == 'test_ok'
+    assert model.index(1, 1).data(Qt.DisplayRole) == 't.M.test_ok'
     assert model.index(1, 1).data(Qt.ToolTipRole) == 'test_foo.MyTest.test_ok'
     assert model.index(1, 2).data(Qt.DisplayRole) == ''


### PR DESCRIPTION
This is a further iteration of PR #75 which hides the module name when displaying test names in the plugin. As suggested there, this PR abbreviates the module name.

After:
![abbrev-after](https://user-images.githubusercontent.com/7941918/34469568-fa20aa52-ef19-11e7-86b9-1515296b7fa1.png)
As the tooltip shows, the test name `s.b.t.test_a.test_abbreviator_with_second_word_prefix_of_first` stands for `spyder_test.backends.tests.test_abbreviator.test_abbreviator_with_second_word_prefix_of_first` .

Before:
![abbrev-before](https://user-images.githubusercontent.com/7941918/34469575-2f571512-ef1a-11e7-8a26-380173c6a0bb.png)
