### PR TITLE
Handle errors encountered when py.test collect tests

### DIFF
--- a/spyder_unittest/backend/abbreviator.py
+++ b/spyder_unittest/backend/abbreviator.py
@@ -12,7 +12,8 @@ class Abbreviator:
 
     First, all names are split in components separated by full stop (like
     module names in Python). Every component is abbreviated by the smallest
-    prefix not shared by other names in the same directory.
+    prefix not shared by other names in the same directory, except for the
+    last component which is not changed.
 
     Attributes
     ----------
@@ -43,12 +44,10 @@ class Abbreviator:
         ---------
         name : str
         """
+        if '.' not in name:
+            return
         len_abbrev = 1
-        if '.' in name:
-            start, rest = name.split('.', 1)
-        else:
-            start = name
-            rest = None
+        start, rest = name.split('.', 1)
         for other in self.dic:
             if start[:len_abbrev] == other[:len_abbrev]:
                 if start == other:
@@ -67,8 +66,7 @@ class Abbreviator:
                         self.dic[other][0] = other[:len_abbrev]
         else:
             self.dic[start] = [start[:len_abbrev], Abbreviator()]
-        if rest:
-            self.dic[start][1].add(rest)
+        self.dic[start][1].add(rest)
 
     def abbreviate(self, name):
         """Return abbreviation of name."""
@@ -77,5 +75,5 @@ class Abbreviator:
             res = (self.dic[start][0]
                    + '.' + self.dic[start][1].abbreviate(rest))
         else:
-            res = self.dic[name][0]
+            res = name
         return res

--- a/spyder_unittest/backend/noserunner.py
+++ b/spyder_unittest/backend/noserunner.py
@@ -60,8 +60,8 @@ class NoseRunner(RunnerBase):
         for testcase in data:
             category = Category.OK
             status = 'ok'
-            module = testcase.get('classname')
-            name = testcase.get('name')
+            name = '{}.{}'.format(testcase.get('classname'),
+                                  testcase.get('name'))
             message = ''
             time = float(testcase.get('time'))
             extras = []
@@ -92,7 +92,6 @@ class NoseRunner(RunnerBase):
 
             extra_text = '\n\n'.join(extras)
             testresults.append(
-                TestResult(category, status, name, module, message, time,
-                           extra_text))
+                TestResult(category, status, name, message, time, extra_text))
 
         return testresults

--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -10,8 +10,7 @@ import os
 
 # Local imports
 from spyder_unittest.backend.jsonstream import JSONStreamReader
-from spyder_unittest.backend.runnerbase import (Category, RunnerBase,
-                                                TestDetails, TestResult)
+from spyder_unittest.backend.runnerbase import Category, RunnerBase, TestResult
 
 
 class PyTestRunner(RunnerBase):
@@ -59,10 +58,10 @@ class PyTestRunner(RunnerBase):
         for result_item in output:
             if result_item['event'] == 'collected':
                 collected_list.append(
-                        self.logreport_collected_to_testdetails(result_item))
+                        self.logreport_collected_to_str(result_item))
             elif result_item['event'] == 'starttest':
                 starttest_list.append(
-                        self.logreport_starttest_to_testdetails(result_item))
+                        self.logreport_starttest_to_str(result_item))
             elif result_item['event'] == 'logreport':
                 result_list.append(self.logreport_to_testresult(result_item))
             elif result_item['event'] == 'finished':
@@ -86,16 +85,16 @@ class PyTestRunner(RunnerBase):
             name = name[:-3]
         return name.replace('/', '.')
 
-    def logreport_collected_to_testdetails(self, report):
-        """Convert a 'collected' logreport to a TestDetails."""
+    def logreport_collected_to_str(self, report):
+        """Convert a 'collected' logreport to a str."""
         module = self.normalize_module_name(report['module'])
-        return TestDetails(report['name'], module)
+        return '{}.{}'.format(module, report['name'])
 
-    def logreport_starttest_to_testdetails(self, report):
-        """Convert a 'starttest' logreport to a TestDetails."""
+    def logreport_starttest_to_str(self, report):
+        """Convert a 'starttest' logreport to a str."""
         module, name = report['nodeid'].split('::', 1)
         module = self.normalize_module_name(module)
-        return TestDetails(name, module)
+        return '{}.{}'.format(module, name)
 
     def logreport_to_testresult(self, report):
         """Convert a logreport sent by test process to a TestResult."""
@@ -110,6 +109,7 @@ class PyTestRunner(RunnerBase):
             status = report['outcome']
         module, name = report['nodeid'].split('::', 1)
         module = self.normalize_module_name(module)
+        testname = '{}.{}'.format(module, name)
         duration = report['duration']
         message = report['message'] if 'message' in report else ''
         if 'longrepr' not in report:
@@ -122,7 +122,7 @@ class PyTestRunner(RunnerBase):
             for (heading, text) in report['sections']:
                 extra_text += '----- {} -----\n'.format(heading)
                 extra_text += text
-        result = TestResult(cat, status, name, module, message=message,
+        result = TestResult(cat, status, testname, message=message,
                             time=duration, extra_text=extra_text)
         return result
 

--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -58,16 +58,14 @@ class PyTestRunner(RunnerBase):
 
         for result_item in output:
             if result_item['event'] == 'collected':
-                collected_list.append(
-                        self.logreport_collected_to_str(result_item))
+                collected_list.append(logreport_collected_to_str(result_item))
             elif result_item['event'] == 'collecterror':
                 collecterror_list.append(
-                        self.logreport_collecterror_to_tuple(result_item))
+                        logreport_collecterror_to_tuple(result_item))
             elif result_item['event'] == 'starttest':
-                starttest_list.append(
-                        self.logreport_starttest_to_str(result_item))
+                starttest_list.append(logreport_starttest_to_str(result_item))
             elif result_item['event'] == 'logreport':
-                result_list.append(self.logreport_to_testresult(result_item))
+                result_list.append(logreport_to_testresult(result_item))
             elif result_item['event'] == 'finished':
                 self.output = result_item['stdout']
 
@@ -80,64 +78,6 @@ class PyTestRunner(RunnerBase):
         if result_list:
             self.sig_testresult.emit(result_list)
 
-    def normalize_module_name(self, name):
-        """
-        Convert module name reported by pytest to Python conventions.
-
-        This function strips the .py suffix and replaces '/' by '.', so that
-        'ham/spam.py' becomes 'ham.spam'.
-        """
-        # TODO: Move this function and others that don't use self out of class?
-        if name.endswith('.py'):
-            name = name[:-3]
-        return name.replace('/', '.')
-
-    def logreport_collected_to_str(self, report):
-        """Convert a 'collected' logreport to a str."""
-        module = self.normalize_module_name(report['module'])
-        return '{}.{}'.format(module, report['name'])
-
-    def logreport_collecterror_to_tuple(self, report):
-        """Convert a 'collecterror' logreport to a (str, str) tuple."""
-        module = self.normalize_module_name(report['nodeid'])
-        return (module, report['longrepr'])
-
-    def logreport_starttest_to_str(self, report):
-        """Convert a 'starttest' logreport to a str."""
-        module, name = report['nodeid'].split('::', 1)
-        module = self.normalize_module_name(module)
-        return '{}.{}'.format(module, name)
-
-    def logreport_to_testresult(self, report):
-        """Convert a logreport sent by test process to a TestResult."""
-        if report['outcome'] == 'passed':
-            cat = Category.OK
-            status = 'ok'
-        elif report['outcome'] == 'failed':
-            cat = Category.FAIL
-            status = 'failure'
-        else:
-            cat = Category.SKIP
-            status = report['outcome']
-        module, name = report['nodeid'].split('::', 1)
-        module = self.normalize_module_name(module)
-        testname = '{}.{}'.format(module, name)
-        duration = report['duration']
-        message = report['message'] if 'message' in report else ''
-        if 'longrepr' not in report:
-            extra_text = ''
-        elif isinstance(report['longrepr'], list):
-            extra_text = report['longrepr'][2]
-        else:
-            extra_text = report['longrepr']
-        if 'sections' in report:
-            for (heading, text) in report['sections']:
-                extra_text += '----- {} -----\n'.format(heading)
-                extra_text += text
-        result = TestResult(cat, status, testname, message=message,
-                            time=duration, extra_text=extra_text)
-        return result
-
     def finished(self):
         """
         Called when the unit test process has finished.
@@ -145,3 +85,68 @@ class PyTestRunner(RunnerBase):
         This function emits `sig_finished`.
         """
         self.sig_finished.emit(None, self.output)
+
+
+def normalize_module_name(name):
+    """
+    Convert module name reported by pytest to Python conventions.
+
+    This function strips the .py suffix and replaces '/' by '.', so that
+    'ham/spam.py' becomes 'ham.spam'.
+    """
+    if name.endswith('.py'):
+        name = name[:-3]
+    return name.replace('/', '.')
+
+
+def convert_nodeid_to_testname(nodeid):
+    """Convert a nodeid to a test name."""
+    module, name = nodeid.split('::', 1)
+    module = normalize_module_name(module)
+    return '{}.{}'.format(module, name)
+
+
+def logreport_collected_to_str(report):
+    """Convert a 'collected' logreport to a str."""
+    module = normalize_module_name(report['module'])
+    return '{}.{}'.format(module, report['name'])
+
+
+def logreport_collecterror_to_tuple(report):
+    """Convert a 'collecterror' logreport to a (str, str) tuple."""
+    module = normalize_module_name(report['nodeid'])
+    return (module, report['longrepr'])
+
+
+def logreport_starttest_to_str(report):
+    """Convert a 'starttest' logreport to a str."""
+    return convert_nodeid_to_testname(report['nodeid'])
+
+
+def logreport_to_testresult(report):
+    """Convert a logreport sent by test process to a TestResult."""
+    if report['outcome'] == 'passed':
+        cat = Category.OK
+        status = 'ok'
+    elif report['outcome'] == 'failed':
+        cat = Category.FAIL
+        status = 'failure'
+    else:
+        cat = Category.SKIP
+        status = report['outcome']
+    testname = convert_nodeid_to_testname(report['nodeid'])
+    duration = report['duration']
+    message = report['message'] if 'message' in report else ''
+    if 'longrepr' not in report:
+        extra_text = ''
+    elif isinstance(report['longrepr'], list):
+        extra_text = report['longrepr'][2]
+    else:
+        extra_text = report['longrepr']
+    if 'sections' in report:
+        for (heading, text) in report['sections']:
+            extra_text += '----- {} -----\n'.format(heading)
+            extra_text += text
+    result = TestResult(cat, status, testname, message=message,
+                        time=duration, extra_text=extra_text)
+    return result

--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -52,6 +52,7 @@ class PyTestRunner(RunnerBase):
             list of decoded Python object sent by test process.
         """
         collected_list = []
+        collecterror_list = []
         starttest_list = []
         result_list = []
 
@@ -59,6 +60,9 @@ class PyTestRunner(RunnerBase):
             if result_item['event'] == 'collected':
                 collected_list.append(
                         self.logreport_collected_to_str(result_item))
+            elif result_item['event'] == 'collecterror':
+                collecterror_list.append(
+                        self.logreport_collecterror_to_tuple(result_item))
             elif result_item['event'] == 'starttest':
                 starttest_list.append(
                         self.logreport_starttest_to_str(result_item))
@@ -69,6 +73,8 @@ class PyTestRunner(RunnerBase):
 
         if collected_list:
             self.sig_collected.emit(collected_list)
+        if collecterror_list:
+            self.sig_collecterror.emit(collecterror_list)
         if starttest_list:
             self.sig_starttest.emit(starttest_list)
         if result_list:
@@ -89,6 +95,11 @@ class PyTestRunner(RunnerBase):
         """Convert a 'collected' logreport to a str."""
         module = self.normalize_module_name(report['module'])
         return '{}.{}'.format(module, report['name'])
+
+    def logreport_collecterror_to_tuple(self, report):
+        """Convert a 'collecterror' logreport to a (str, str) tuple."""
+        module = self.normalize_module_name(report['nodeid'])
+        return (module, report['longrepr'])
 
     def logreport_starttest_to_str(self, report):
         """Convert a 'starttest' logreport to a str."""

--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -87,6 +87,7 @@ class PyTestRunner(RunnerBase):
         This function strips the .py suffix and replaces '/' by '.', so that
         'ham/spam.py' becomes 'ham.spam'.
         """
+        # TODO: Move this function and others that don't use self out of class?
         if name.endswith('.py'):
             name = name[:-3]
         return name.replace('/', '.')

--- a/spyder_unittest/backend/pytestworker.py
+++ b/spyder_unittest/backend/pytestworker.py
@@ -45,6 +45,15 @@ class SpyderPlugin():
         """Constructor."""
         self.writer = writer
 
+    def pytest_collectreport(self, report):
+        """Called by py.test after collecting tests from a file."""
+        if report.outcome == 'failed':
+            self.writer.write({
+                    'event': 'collecterror',
+                    'nodeid': report.nodeid,
+                    'longrepr': report.longrepr.longrepr
+            })
+
     def pytest_itemcollected(self, item):
         """Called by py.test when a test item is collected."""
         self.writer.write({

--- a/spyder_unittest/backend/runnerbase.py
+++ b/spyder_unittest/backend/runnerbase.py
@@ -6,7 +6,6 @@
 """Classes for running tests within various frameworks."""
 
 # Standard library imports
-from collections import namedtuple
 import os
 import tempfile
 
@@ -21,9 +20,6 @@ try:
 except ImportError:  # Python 2
     from pkgutil import find_loader as find_spec_or_loader
 
-# Class with details of the tests
-TestDetails = namedtuple('TestDetails', ['name', 'module'])
-
 
 class Category:
     """Enum type representing category of test result."""
@@ -37,7 +33,7 @@ class Category:
 class TestResult:
     """Class representing the result of running a single test."""
 
-    def __init__(self, category, status, name, module, message='', time=None,
+    def __init__(self, category, status, name, message='', time=None,
                  extra_text=''):
         """
         Construct a test result.
@@ -47,7 +43,6 @@ class TestResult:
         category : Category
         status : str
         name : str
-        module : str
         message : str
         time : float or None
         extra_text : str
@@ -55,7 +50,6 @@ class TestResult:
         self.category = category
         self.status = status
         self.name = name
-        self.module = module
         self.message = message
         self.time = time
         extra_text = extra_text.rstrip()
@@ -92,9 +86,9 @@ class RunnerBase(QObject):
 
     Signals
     -------
-    sig_collected(list of TestDetails)
+    sig_collected(list of str)
         Emitted when tests are collected.
-    sig_starttest(list of TestDetails)
+    sig_starttest(list of str)
         Emitted just before tests are run.
     sig_testresult(list of TestResult)
         Emitted when tests are finished.

--- a/spyder_unittest/backend/runnerbase.py
+++ b/spyder_unittest/backend/runnerbase.py
@@ -88,6 +88,9 @@ class RunnerBase(QObject):
     -------
     sig_collected(list of str)
         Emitted when tests are collected.
+    sig_collecterror(list of (str, str) tuples)
+        Emitted when errors are encountered during collection. First element
+        of tuple is test name, second element is error message.
     sig_starttest(list of str)
         Emitted just before tests are run.
     sig_testresult(list of TestResult)
@@ -98,6 +101,7 @@ class RunnerBase(QObject):
     """
 
     sig_collected = Signal(object)
+    sig_collecterror = Signal(object)
     sig_starttest = Signal(object)
     sig_testresult = Signal(object)
     sig_finished = Signal(object, str)

--- a/spyder_unittest/backend/tests/test_abbreviator.py
+++ b/spyder_unittest/backend/tests/test_abbreviator.py
@@ -12,37 +12,48 @@ from spyder_unittest.backend.abbreviator import Abbreviator
 def test_abbreviator_with_one_word():
     abb = Abbreviator()
     abb.add('ham')
-    assert abb.abbreviate('ham') == 'h'
+    assert abb.abbreviate('ham') == 'ham'
+
+def test_abbreviator_with_one_word_with_two_components():
+    abb = Abbreviator()
+    abb.add('ham.spam')
+    assert abb.abbreviate('ham.spam') == 'h.spam'
+
+def test_abbreviator_with_one_word_with_three_components():
+    abb = Abbreviator()
+    abb.add('ham.spam.eggs')
+    assert abb.abbreviate('ham.spam.eggs') == 'h.s.eggs'
 
 def test_abbreviator_without_common_prefix():
-    abb = Abbreviator(['ham', 'spam'])
-    assert abb.abbreviate('ham') == 'h'
-    assert abb.abbreviate('spam') == 's'
+    abb = Abbreviator(['ham.foo', 'spam.foo'])
+    assert abb.abbreviate('ham.foo') == 'h.foo'
+    assert abb.abbreviate('spam.foo') == 's.foo'
 
 def test_abbreviator_with_prefix():
-    abb = Abbreviator(['test_ham', 'test_spam'])
-    assert abb.abbreviate('test_ham') == 'test_h'
-    assert abb.abbreviate('test_spam') == 'test_s'
+    abb = Abbreviator(['test_ham.x', 'test_spam.x'])
+    assert abb.abbreviate('test_ham.x') == 'test_h.x'
+    assert abb.abbreviate('test_spam.x') == 'test_s.x'
 
 def test_abbreviator_with_first_word_prefix_of_second():
-    abb = Abbreviator(['ham', 'hameggs'])
-    assert abb.abbreviate('ham') == 'ham'
-    assert abb.abbreviate('hameggs') == 'hame'
+    abb = Abbreviator(['ham.x', 'hameggs.x'])
+    assert abb.abbreviate('ham.x') == 'ham.x'
+    assert abb.abbreviate('hameggs.x') == 'hame.x'
 
 def test_abbreviator_with_second_word_prefix_of_first():
-    abb = Abbreviator(['hameggs', 'ham'])
-    assert abb.abbreviate('hameggs') == 'hame'
-    assert abb.abbreviate('ham') == 'ham'
+    abb = Abbreviator(['hameggs.x', 'ham.x'])
+    assert abb.abbreviate('hameggs.x') == 'hame.x'
+    assert abb.abbreviate('ham.x') == 'ham.x'
 
 def test_abbreviator_with_three_words():
-    abb = Abbreviator(['hamegg', 'hameggs', 'hall'])
-    assert abb.abbreviate('hamegg') == 'hamegg'
-    assert abb.abbreviate('hameggs') == 'hameggs'
-    assert abb.abbreviate('hall') == 'hal'
+    abb = Abbreviator(['hamegg.x', 'hameggs.x', 'hall.x'])
+    assert abb.abbreviate('hamegg.x') == 'hamegg.x'
+    assert abb.abbreviate('hameggs.x') == 'hameggs.x'
+    assert abb.abbreviate('hall.x') == 'hal.x'
 
 def test_abbreviator_with_multilevel():
-    abb = Abbreviator(['ham.eggs', 'ham.spam', 'eggs.ham', 'eggs.hamspam'])
-    assert abb.abbreviate('ham.eggs') == 'h.e'
-    assert abb.abbreviate('ham.spam') == 'h.s'
-    assert abb.abbreviate('eggs.ham') == 'e.ham'
-    assert abb.abbreviate('eggs.hamspam') == 'e.hams'
+    abb = Abbreviator(['ham.eggs.foo', 'ham.spam.bar', 'eggs.ham.foo',
+                       'eggs.hamspam.bar'])
+    assert abb.abbreviate('ham.eggs.foo') == 'h.e.foo'
+    assert abb.abbreviate('ham.spam.bar') == 'h.s.bar'
+    assert abb.abbreviate('eggs.ham.foo') == 'e.ham.foo'
+    assert abb.abbreviate('eggs.hamspam.bar') == 'e.hams.bar'

--- a/spyder_unittest/backend/tests/test_noserunner.py
+++ b/spyder_unittest/backend/tests/test_noserunner.py
@@ -28,24 +28,21 @@ def test_noserunner_load_data(tmpdir):
 
     assert results[0].category == Category.OK
     assert results[0].status == 'ok'
-    assert results[0].name == 'test1'
-    assert results[0].module == 'test_foo'
+    assert results[0].name == 'test_foo.test1'
     assert results[0].message == ''
     assert results[0].time == 0.04
     assert results[0].extra_text == []
 
     assert results[1].category == Category.FAIL
     assert results[1].status == 'failure'
-    assert results[1].name == 'test2'
-    assert results[1].module == 'test_foo'
+    assert results[1].name == 'test_foo.test2'
     assert results[1].message == 'failure message'
     assert results[1].time == 0.01
     assert results[1].extra_text == ['text']
 
     assert results[2].category == Category.SKIP
     assert results[2].status == 'skipped'
-    assert results[2].name == 'test3'
-    assert results[2].module == 'test_foo'
+    assert results[2].name == 'test_foo.test3'
     assert results[2].message == 'skip message'
     assert results[2].time == 0.05
     assert results[2].extra_text == ['text2']

--- a/spyder_unittest/backend/tests/test_pytestrunner.py
+++ b/spyder_unittest/backend/tests/test_pytestrunner.py
@@ -26,7 +26,6 @@ except ImportError:
 def test_pytestrunner_is_installed():
     assert PyTestRunner(None).is_installed()
 
-
 def test_pytestrunner_start(monkeypatch):
     MockQProcess = Mock()
     monkeypatch.setattr('spyder_unittest.backend.runnerbase.QProcess',
@@ -71,7 +70,6 @@ def test_pytestrunner_start(monkeypatch):
 
     assert runner.reader is mock_reader
 
-
 def test_pytestrunner_read_output(monkeypatch):
     runner = PyTestRunner(None)
     runner.process = Mock()
@@ -84,7 +82,6 @@ def test_pytestrunner_read_output(monkeypatch):
     runner.read_output()
     assert runner.reader.consume.called_once_with('encoded')
     assert runner.process_output.called_once_with('decoded')
-
 
 def test_pytestrunner_process_output_with_collected(qtbot):
     runner = PyTestRunner(None)
@@ -102,6 +99,17 @@ def test_pytestrunner_process_output_with_collected(qtbot):
     expected = ['spam.ham', 'eggs.bacon']
     assert blocker.args == [expected]
 
+def test_pytestrunner_process_output_with_collecterror(qtbot):
+    runner = PyTestRunner(None)
+    output = [{
+            'event': 'collecterror',
+            'nodeid': 'ham/spam.py',
+            'longrepr': 'msg'
+    }]
+    with qtbot.waitSignal(runner.sig_collecterror) as blocker:
+        runner.process_output(output)
+    expected = [('ham.spam', 'msg')]
+    assert blocker.args == [expected]
 
 def test_pytestrunner_process_output_with_starttest(qtbot):
     runner = PyTestRunner(None)
@@ -111,7 +119,6 @@ def test_pytestrunner_process_output_with_starttest(qtbot):
         runner.process_output(output)
     expected = ['ham.spam.ham', 'ham.eggs.bacon']
     assert blocker.args == [expected]
-
 
 def test_pytestrunner_process_output_with_logreport_passed(qtbot):
     runner = PyTestRunner(None)
@@ -127,7 +134,6 @@ def test_pytestrunner_process_output_with_logreport_passed(qtbot):
     expected = [TestResult(Category.OK, 'ok', 'foo.bar', time=42)]
     assert blocker.args == [expected]
 
-
 def test_pytestrunner_logreport_to_testresult_passed():
     runner = PyTestRunner(None)
     report = {
@@ -139,7 +145,6 @@ def test_pytestrunner_logreport_to_testresult_passed():
     }
     expected = TestResult(Category.OK, 'ok', 'foo.bar', time=42)
     assert runner.logreport_to_testresult(report) == expected
-
 
 def test_pytestrunner_logreport_to_testresult_failed():
     runner = PyTestRunner(None)
@@ -156,7 +161,6 @@ def test_pytestrunner_logreport_to_testresult_failed():
                           message='msg', time=42, extra_text='exception text')
     assert runner.logreport_to_testresult(report) == expected
 
-
 def test_pytestrunner_logreport_to_testresult_skipped():
     runner = PyTestRunner(None)
     report = {
@@ -170,7 +174,6 @@ def test_pytestrunner_logreport_to_testresult_skipped():
     expected = TestResult(Category.SKIP, 'skipped', 'foo.bar',
                           time=42, extra_text='skipmsg')
     assert runner.logreport_to_testresult(report) == expected
-
 
 def test_pytestrunner_logreport_to_testresult_xfail():
     runner = PyTestRunner(None)
@@ -188,7 +191,6 @@ def test_pytestrunner_logreport_to_testresult_xfail():
                           message='msg', time=42, extra_text='exception text')
     assert runner.logreport_to_testresult(report) == expected
 
-
 def test_pytestrunner_logreport_to_testresult_xpass():
     runner = PyTestRunner(None)
     report = {
@@ -201,7 +203,6 @@ def test_pytestrunner_logreport_to_testresult_xpass():
     }
     expected = TestResult(Category.OK, 'ok', 'foo.bar', time=42)
     assert runner.logreport_to_testresult(report) == expected
-
 
 def test_pytestrunner_logreport_to_testresult_with_output():
     runner = PyTestRunner(None)

--- a/spyder_unittest/backend/tests/test_pytestrunner.py
+++ b/spyder_unittest/backend/tests/test_pytestrunner.py
@@ -13,7 +13,8 @@ from qtpy.QtCore import QByteArray
 from spyder.utils.misc import get_python_executable
 
 # Local imports
-from spyder_unittest.backend.pytestrunner import PyTestRunner
+from spyder_unittest.backend.pytestrunner import (PyTestRunner,
+                                                  logreport_to_testresult)
 from spyder_unittest.backend.runnerbase import Category, TestResult
 from spyder_unittest.widgets.configdialog import Config
 
@@ -134,8 +135,7 @@ def test_pytestrunner_process_output_with_logreport_passed(qtbot):
     expected = [TestResult(Category.OK, 'ok', 'foo.bar', time=42)]
     assert blocker.args == [expected]
 
-def test_pytestrunner_logreport_to_testresult_passed():
-    runner = PyTestRunner(None)
+def test_logreport_to_testresult_passed():
     report = {
         'event': 'logreport',
         'when': 'call',
@@ -144,10 +144,9 @@ def test_pytestrunner_logreport_to_testresult_passed():
         'duration': 42
     }
     expected = TestResult(Category.OK, 'ok', 'foo.bar', time=42)
-    assert runner.logreport_to_testresult(report) == expected
+    assert logreport_to_testresult(report) == expected
 
-def test_pytestrunner_logreport_to_testresult_failed():
-    runner = PyTestRunner(None)
+def test_logreport_to_testresult_failed():
     report = {
         'event': 'logreport',
         'when': 'call',
@@ -159,10 +158,9 @@ def test_pytestrunner_logreport_to_testresult_failed():
     }
     expected = TestResult(Category.FAIL, 'failure', 'foo.bar',
                           message='msg', time=42, extra_text='exception text')
-    assert runner.logreport_to_testresult(report) == expected
+    assert logreport_to_testresult(report) == expected
 
-def test_pytestrunner_logreport_to_testresult_skipped():
-    runner = PyTestRunner(None)
+def test_logreport_to_testresult_skipped():
     report = {
         'event': 'logreport',
         'when': 'setup',
@@ -173,10 +171,9 @@ def test_pytestrunner_logreport_to_testresult_skipped():
     }
     expected = TestResult(Category.SKIP, 'skipped', 'foo.bar',
                           time=42, extra_text='skipmsg')
-    assert runner.logreport_to_testresult(report) == expected
+    assert logreport_to_testresult(report) == expected
 
-def test_pytestrunner_logreport_to_testresult_xfail():
-    runner = PyTestRunner(None)
+def test_logreport_to_testresult_xfail():
     report = {
         'event': 'logreport',
         'when': 'call',
@@ -189,10 +186,9 @@ def test_pytestrunner_logreport_to_testresult_xfail():
     }
     expected = TestResult(Category.SKIP, 'skipped', 'foo.bar',
                           message='msg', time=42, extra_text='exception text')
-    assert runner.logreport_to_testresult(report) == expected
+    assert logreport_to_testresult(report) == expected
 
-def test_pytestrunner_logreport_to_testresult_xpass():
-    runner = PyTestRunner(None)
+def test_logreport_to_testresult_xpass():
     report = {
         'event': 'logreport',
         'when': 'call',
@@ -202,10 +198,9 @@ def test_pytestrunner_logreport_to_testresult_xpass():
         'wasxfail': ''
     }
     expected = TestResult(Category.OK, 'ok', 'foo.bar', time=42)
-    assert runner.logreport_to_testresult(report) == expected
+    assert logreport_to_testresult(report) == expected
 
-def test_pytestrunner_logreport_to_testresult_with_output():
-    runner = PyTestRunner(None)
+def test_logreport_to_testresult_with_output():
     report = {
         'event': 'logreport',
         'when': 'call',
@@ -219,4 +214,4 @@ def test_pytestrunner_logreport_to_testresult_with_output():
            '----- Captured stderr call -----\nspam\n')
     expected = TestResult(Category.OK, 'ok', 'foo.bar', time=42,
                           extra_text=txt)
-    assert runner.logreport_to_testresult(report) == expected
+    assert logreport_to_testresult(report) == expected

--- a/spyder_unittest/backend/tests/test_pytestrunner.py
+++ b/spyder_unittest/backend/tests/test_pytestrunner.py
@@ -14,8 +14,7 @@ from spyder.utils.misc import get_python_executable
 
 # Local imports
 from spyder_unittest.backend.pytestrunner import PyTestRunner
-from spyder_unittest.backend.runnerbase import (Category, TestDetails,
-                                                TestResult)
+from spyder_unittest.backend.runnerbase import Category, TestResult
 from spyder_unittest.widgets.configdialog import Config
 
 try:
@@ -100,10 +99,7 @@ def test_pytestrunner_process_output_with_collected(qtbot):
     }]
     with qtbot.waitSignal(runner.sig_collected) as blocker:
         runner.process_output(output)
-    expected = [
-        TestDetails(name='ham', module='spam'),
-        TestDetails(name='bacon', module='eggs')
-    ]
+    expected = ['spam.ham', 'eggs.bacon']
     assert blocker.args == [expected]
 
 
@@ -113,10 +109,7 @@ def test_pytestrunner_process_output_with_starttest(qtbot):
               {'event': 'starttest', 'nodeid': 'ham/eggs.py::bacon'}]
     with qtbot.waitSignal(runner.sig_starttest) as blocker:
         runner.process_output(output)
-    expected = [
-        TestDetails(name='ham', module='ham.spam'),
-        TestDetails(name='bacon', module='ham.eggs')
-    ]
+    expected = ['ham.spam.ham', 'ham.eggs.bacon']
     assert blocker.args == [expected]
 
 
@@ -131,7 +124,7 @@ def test_pytestrunner_process_output_with_logreport_passed(qtbot):
     }]
     with qtbot.waitSignal(runner.sig_testresult) as blocker:
         runner.process_output(output)
-    expected = [TestResult(Category.OK, 'ok', 'bar', 'foo', time=42)]
+    expected = [TestResult(Category.OK, 'ok', 'foo.bar', time=42)]
     assert blocker.args == [expected]
 
 
@@ -144,7 +137,7 @@ def test_pytestrunner_logreport_to_testresult_passed():
         'nodeid': 'foo.py::bar',
         'duration': 42
     }
-    expected = TestResult(Category.OK, 'ok', 'bar', 'foo', time=42)
+    expected = TestResult(Category.OK, 'ok', 'foo.bar', time=42)
     assert runner.logreport_to_testresult(report) == expected
 
 
@@ -159,7 +152,7 @@ def test_pytestrunner_logreport_to_testresult_failed():
         'message': 'msg',
         'longrepr': 'exception text'
     }
-    expected = TestResult(Category.FAIL, 'failure', 'bar', 'foo',
+    expected = TestResult(Category.FAIL, 'failure', 'foo.bar',
                           message='msg', time=42, extra_text='exception text')
     assert runner.logreport_to_testresult(report) == expected
 
@@ -174,7 +167,7 @@ def test_pytestrunner_logreport_to_testresult_skipped():
         'duration': 42,
         'longrepr': ['file', 24, 'skipmsg']
     }
-    expected = TestResult(Category.SKIP, 'skipped', 'bar', 'foo',
+    expected = TestResult(Category.SKIP, 'skipped', 'foo.bar',
                           time=42, extra_text='skipmsg')
     assert runner.logreport_to_testresult(report) == expected
 
@@ -191,7 +184,7 @@ def test_pytestrunner_logreport_to_testresult_xfail():
         'longrepr': 'exception text',
         'wasxfail': ''
     }
-    expected = TestResult(Category.SKIP, 'skipped', 'bar', 'foo',
+    expected = TestResult(Category.SKIP, 'skipped', 'foo.bar',
                           message='msg', time=42, extra_text='exception text')
     assert runner.logreport_to_testresult(report) == expected
 
@@ -206,7 +199,7 @@ def test_pytestrunner_logreport_to_testresult_xpass():
         'duration': 42,
         'wasxfail': ''
     }
-    expected = TestResult(Category.OK, 'ok', 'bar', 'foo', time=42)
+    expected = TestResult(Category.OK, 'ok', 'foo.bar', time=42)
     assert runner.logreport_to_testresult(report) == expected
 
 
@@ -223,6 +216,6 @@ def test_pytestrunner_logreport_to_testresult_with_output():
     }
     txt = ('----- Captured stdout call -----\nham\n'
            '----- Captured stderr call -----\nspam\n')
-    expected = TestResult(Category.OK, 'ok', 'bar', 'foo', time=42,
+    expected = TestResult(Category.OK, 'ok', 'foo.bar', time=42,
                           extra_text=txt)
     assert runner.logreport_to_testresult(report) == expected

--- a/spyder_unittest/backend/tests/test_unittestrunner.py
+++ b/spyder_unittest/backend/tests/test_unittestrunner.py
@@ -20,15 +20,13 @@ extra text\n"""
 
     assert res[0].category == Category.OK
     assert res[0].status == 'ok'
-    assert res[0].name == 'test_isupper'
-    assert res[0].module == 'teststringmethods.TestStringMethods'
+    assert res[0].name == 'teststringmethods.TestStringMethods.test_isupper'
     assert res[0].message == ''
     assert res[0].extra_text == []
 
     assert res[1].category == Category.OK
     assert res[1].status == 'ok'
-    assert res[1].name == 'test_split'
-    assert res[1].module == 'teststringmethods.TestStringMethods'
+    assert res[1].name == 'teststringmethods.TestStringMethods.test_split'
     assert res[1].message == ''
     assert res[1].extra_text == ['extra text\n']
 
@@ -46,8 +44,7 @@ OK
     assert len(res) == 1
     assert res[0].category == Category.OK
     assert res[0].status == 'ok'
-    assert res[0].name == 'test1'
-    assert res[0].module == 'test_foo.Bar'
+    assert res[0].name == 'test_foo.Bar.test1'
     assert res[0].extra_text == []
 
 
@@ -69,15 +66,13 @@ AssertionError: 1 != 2
 
     assert res[0].category == Category.FAIL
     assert res[0].status == 'FAIL'
-    assert res[0].name == 'test1'
-    assert res[0].module == 'test_foo.Bar'
+    assert res[0].name == 'test_foo.Bar.test1'
     assert res[0].extra_text[0].startswith('Traceback')
     assert res[0].extra_text[-1].endswith('AssertionError: 1 != 2\n')
 
     assert res[1].category == Category.OK
     assert res[1].status == 'ok'
-    assert res[1].name == 'test2'
-    assert res[1].module == 'test_foo.Bar'
+    assert res[1].name == 'test_foo.Bar.test2'
     assert res[1].extra_text == []
 
 

--- a/spyder_unittest/backend/unittestrunner.py
+++ b/spyder_unittest/backend/unittestrunner.py
@@ -55,14 +55,9 @@ class UnittestRunner(RunnerBase):
                     cat = Category.FAIL
                 else:
                     cat = Category.SKIP
-                tr = TestResult(
-                    category=cat,
-                    status=data[2],
-                    name=data[0],
-                    module=data[1],
-                    message=data[3],
-                    time=0,
-                    extra_text='')
+                name = '{}.{}'.format(data[1], data[0])
+                tr = TestResult(category=cat, status=data[2], name=name,
+                                message=data[3], time=0, extra_text='')
                 res.append(tr)
                 line_index += 1
                 test_index = -1
@@ -73,7 +68,7 @@ class UnittestRunner(RunnerBase):
                 line_index = data[0]
                 test_index = next(
                     i for i, tr in enumerate(res)
-                    if tr.name == data[1] and tr.module == data[2])
+                    if tr.name == '{}.{}'.format(data[2], data[1]))
 
             data = self.try_parse_footer(lines, line_index)
             if data:

--- a/spyder_unittest/widgets/datatree.py
+++ b/spyder_unittest/widgets/datatree.py
@@ -66,6 +66,7 @@ class TestDataView(QTreeView):
         """Called when rows are inserted."""
         QTreeView.rowsInserted(self, parent, firstRow, lastRow)
         self.resizeColumns()
+        self.spanFirstColumn(firstRow, lastRow)
 
     def dataChanged(self, topLeft, bottomRight, roles=[]):
         """Called when data in model has changed."""

--- a/spyder_unittest/widgets/datatree.py
+++ b/spyder_unittest/widgets/datatree.py
@@ -153,7 +153,7 @@ class TestDataModel(QAbstractItemModel):
     def testresults(self, new_value):
         """Setter for test results."""
         self.beginResetModel()
-        self.abbreviator = Abbreviator(res.module for res in new_value)
+        self.abbreviator = Abbreviator(res.name for res in new_value)
         self._testresults = new_value
         self.endResetModel()
         self.emit_summary()
@@ -169,7 +169,7 @@ class TestDataModel(QAbstractItemModel):
         firstRow = len(self.testresults)
         lastRow = firstRow + len(new_tests) - 1
         for test in new_tests:
-            self.abbreviator.add(test.module)
+            self.abbreviator.add(test.name)
         self.beginInsertRows(QModelIndex(), firstRow, lastRow)
         self.testresults.extend(new_tests)
         self.endInsertRows()
@@ -190,8 +190,7 @@ class TestDataModel(QAbstractItemModel):
         idx_min = idx_max = None
         for new_result in new_results:
             for (idx, old_result) in enumerate(self.testresults):
-                if (old_result.name == new_result.name
-                        and old_result.module == new_result.module):
+                if old_result.name == new_result.name:
                     self.testresults[idx] = new_result
                     if idx_min is None:
                         idx_min = idx_max = idx
@@ -227,6 +226,7 @@ class TestDataModel(QAbstractItemModel):
         If `role` is `DisplayRole`, then return string to display.
         If `role` is `TooltipRole`, then return string for tool tip.
         If `role` is `FontRole`, then return monospace font for level-2 items.
+        If `role` is `BackgroundRole`, then return background color
         """
         if not index.isValid():
             return None
@@ -239,10 +239,7 @@ class TestDataModel(QAbstractItemModel):
             elif column == STATUS_COLUMN:
                 return self.testresults[row].status
             elif column == NAME_COLUMN:
-                module_abbrev = self.abbreviator.abbreviate(
-                        self.testresults[row].module)
-                return '{0}.{1}'.format(module_abbrev,
-                                        self.testresults[row].name)
+                return self.abbreviator.abbreviate(self.testresults[row].name)
             elif column == MESSAGE_COLUMN:
                 return self.testresults[row].message
             elif column == TIME_COLUMN:
@@ -250,8 +247,7 @@ class TestDataModel(QAbstractItemModel):
                 return str(time * 1e3) if time else ''
         elif role == Qt.ToolTipRole:
             if id == TOPLEVEL_ID and column == NAME_COLUMN:
-                return '{0}.{1}'.format(self.testresults[row].module,
-                                        self.testresults[row].name)
+                return self.testresults[row].name
         elif role == Qt.FontRole:
             if id != TOPLEVEL_ID:
                 return self.monospace_font

--- a/spyder_unittest/widgets/tests/test_datatree.py
+++ b/spyder_unittest/widgets/tests/test_datatree.py
@@ -15,8 +15,8 @@ from spyder_unittest.widgets.datatree import COLORS, TestDataModel
 
 def test_testdatamodel_using_qtmodeltester(qtmodeltester):
     model = TestDataModel()
-    res = [TestResult(Category.OK, 'status', 'bar', 'foo'),
-           TestResult(Category.FAIL, 'error', 'bar', 'foo', 'kadoom', 0,
+    res = [TestResult(Category.OK, 'status', 'foo.bar'),
+           TestResult(Category.FAIL, 'error', 'foo.bar', 'kadoom', 0,
                       'crash!\nboom!')]
     model.testresults = res
     qtmodeltester.check(model)
@@ -24,7 +24,7 @@ def test_testdatamodel_using_qtmodeltester(qtmodeltester):
 
 def test_testdatamodel_shows_abbreviated_name_in_table(qtbot):
     model = TestDataModel()
-    res = TestResult(Category.OK, 'status', 'bar', 'foo', '', 0, '')
+    res = TestResult(Category.OK, 'status', 'foo.bar', '', 0, '')
     model.testresults = [res]
     index = model.index(0, 1)
     assert model.data(index, Qt.DisplayRole) == 'f.bar'
@@ -32,7 +32,7 @@ def test_testdatamodel_shows_abbreviated_name_in_table(qtbot):
 
 def test_testdatamodel_shows_full_name_in_tooltip(qtbot):
     model = TestDataModel()
-    res = TestResult(Category.OK, 'status', 'bar', 'foo', '', 0, '')
+    res = TestResult(Category.OK, 'status', 'foo.bar', '', 0, '')
     model.testresults = [res]
     index = model.index(0, 1)
     assert model.data(index, Qt.ToolTipRole) == 'foo.bar'
@@ -40,8 +40,8 @@ def test_testdatamodel_shows_full_name_in_tooltip(qtbot):
 
 def test_testdatamodel_data_background():
     model = TestDataModel()
-    res = [TestResult(Category.OK, 'status', 'bar', 'foo'),
-           TestResult(Category.FAIL, 'error', 'bar', 'foo', 'kadoom')]
+    res = [TestResult(Category.OK, 'status', 'foo.bar'),
+           TestResult(Category.FAIL, 'error', 'foo.bar', 'kadoom')]
     model.testresults = res
     index = model.index(0, 0)
     assert model.data(index, Qt.BackgroundRole) == COLORS[Category.OK]
@@ -59,14 +59,14 @@ def test_testdatamodel_add_tests(qtbot):
     model = TestDataModel()
     assert model.testresults == []
 
-    result1 = TestResult(Category.OK, 'status', 'bar', 'foo')
+    result1 = TestResult(Category.OK, 'status', 'foo.bar')
     with qtbot.waitSignals([model.rowsInserted, model.sig_summary],
                            check_params_cbs=[check_args1, None],
                            raising=True):
         model.add_testresults([result1])
     assert model.testresults == [result1]
 
-    result2 = TestResult(Category.FAIL, 'error', 'bar', 'foo', 'kadoom')
+    result2 = TestResult(Category.FAIL, 'error', 'foo.bar', 'kadoom')
     with qtbot.waitSignals([model.rowsInserted, model.sig_summary],
                            check_params_cbs=[check_args2, None],
                            raising=True):
@@ -84,9 +84,9 @@ def test_testdatamodel_replace_tests(qtbot):
                 and not bottomRight.parent().isValid())
 
     model = TestDataModel()
-    result1 = TestResult(Category.OK, 'status', 'bar', 'foo')
+    result1 = TestResult(Category.OK, 'status', 'foo.bar')
     model.testresults = [result1]
-    result2 = TestResult(Category.FAIL, 'error', 'bar', 'foo', 'kadoom')
+    result2 = TestResult(Category.FAIL, 'error', 'foo.bar', 'kadoom')
     with qtbot.waitSignals([model.dataChanged, model.sig_summary],
                            check_params_cbs=[check_args, None],
                            raising=True):

--- a/spyder_unittest/widgets/tests/test_unittestgui.py
+++ b/spyder_unittest/widgets/tests/test_unittestgui.py
@@ -59,6 +59,16 @@ def test_unittestwidget_process_finished_with_results_none(qtbot):
     widget.process_finished(None, 'output')
     assert widget.testdatamodel.testresults == results
 
+def test_unittestwidget_replace_pending_with_not_run(qtbot):
+    widget = UnitTestWidget(None)
+    widget.testdatamodel = Mock()
+    results = [TestResult(Category.PENDING, 'pending', 'hammodule.eggs'),
+               TestResult(Category.OK, 'ok', 'hammodule.spam')]
+    widget.testdatamodel.testresults = results
+    widget.replace_pending_with_not_run()
+    expected = [TestResult(Category.SKIP, 'not run', 'hammodule.eggs')]
+    widget.testdatamodel.update_testresults.assert_called_once_with(expected)
+
 def test_unittestwidget_tests_collected(qtbot):
     widget = UnitTestWidget(None)
     widget.testdatamodel = Mock()

--- a/spyder_unittest/widgets/tests/test_unittestgui.py
+++ b/spyder_unittest/widgets/tests/test_unittestgui.py
@@ -76,6 +76,15 @@ def test_unittestwidget_tests_started(qtbot):
     widget.tests_started(details)
     widget.testdatamodel.update_testresults.assert_called_once_with(results)
 
+def test_unittestwidget_tests_collect_error(qtbot):
+    widget = UnitTestWidget(None)
+    widget.testdatamodel = Mock()
+    names_plus_msg = [('hammodule.spam', 'msg')]
+    results = [TestResult(Category.FAIL, 'failure', 'hammodule.spam',
+                          'collection error', extra_text='msg')]
+    widget.tests_collect_error(names_plus_msg)
+    widget.testdatamodel.add_testresults.assert_called_once_with(results)
+
 def test_unittestwidget_tests_yield_results(qtbot):
     widget = UnitTestWidget(None)
     widget.testdatamodel = Mock()

--- a/spyder_unittest/widgets/tests/test_unittestgui.py
+++ b/spyder_unittest/widgets/tests/test_unittestgui.py
@@ -14,8 +14,7 @@ from qtpy.QtCore import Qt
 import pytest
 
 # Local imports
-from spyder_unittest.backend.runnerbase import (Category, TestDetails,
-                                                TestResult)
+from spyder_unittest.backend.runnerbase import Category, TestResult
 from spyder_unittest.widgets.configdialog import Config
 from spyder_unittest.widgets.unittestgui import UnitTestWidget
 
@@ -47,7 +46,7 @@ def test_unittestwidget_process_finished_updates_results(qtbot):
     widget.testdatamodel = Mock()
     widget.testdatamodel.summary = lambda: 'message'
     widget.testdatamodel.testresults = []
-    results = [TestResult(Category.OK, 'ok', 'spam', 'hammodule')]
+    results = [TestResult(Category.OK, 'ok', 'hammodule.spam')]
     widget.process_finished(results, 'output')
     assert widget.testdatamodel.testresults == results
 
@@ -55,7 +54,7 @@ def test_unittestwidget_process_finished_with_results_none(qtbot):
     widget = UnitTestWidget(None)
     widget.testdatamodel = Mock()
     widget.testdatamodel.summary = lambda: 'message'
-    results = [TestResult(Category.OK, 'ok', 'spam', 'hammodule')]
+    results = [TestResult(Category.OK, 'ok', 'hammodule.spam')]
     widget.testdatamodel.testresults = results
     widget.process_finished(None, 'output')
     assert widget.testdatamodel.testresults == results
@@ -63,25 +62,24 @@ def test_unittestwidget_process_finished_with_results_none(qtbot):
 def test_unittestwidget_tests_collected(qtbot):
     widget = UnitTestWidget(None)
     widget.testdatamodel = Mock()
-    details = [TestDetails('spam', 'hammodule'),
-               TestDetails('eggs', 'hammodule') ]
+    details = ['hammodule.spam', 'hammodule.eggs']
     widget.tests_collected(details)
-    results = [TestResult(Category.PENDING, 'pending', 'spam', 'hammodule'),
-               TestResult(Category.PENDING, 'pending', 'eggs', 'hammodule')]
+    results = [TestResult(Category.PENDING, 'pending', 'hammodule.spam'),
+               TestResult(Category.PENDING, 'pending', 'hammodule.eggs')]
     widget.testdatamodel.add_testresults.assert_called_once_with(results)
 
 def test_unittestwidget_tests_started(qtbot):
     widget = UnitTestWidget(None)
     widget.testdatamodel = Mock()
-    details = [TestDetails('spam', 'hammodule')]
-    results = [TestResult(Category.PENDING, 'pending', 'spam', 'hammodule', 'running')]
+    details = ['hammodule.spam']
+    results = [TestResult(Category.PENDING, 'pending', 'hammodule.spam', 'running')]
     widget.tests_started(details)
     widget.testdatamodel.update_testresults.assert_called_once_with(results)
 
 def test_unittestwidget_tests_yield_results(qtbot):
     widget = UnitTestWidget(None)
     widget.testdatamodel = Mock()
-    results = [TestResult(Category.OK, 'ok', 'spam', 'hammodule')]
+    results = [TestResult(Category.OK, 'ok', 'hammodule.spam')]
     widget.tests_yield_result(results)
     widget.testdatamodel.update_testresults.assert_called_once_with(results)
 

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -8,6 +8,7 @@
 from __future__ import with_statement
 
 # Standard library imports
+import copy
 import os.path as osp
 import sys
 
@@ -293,9 +294,22 @@ class UnitTestWidget(QWidget):
         self.log_action.setEnabled(bool(output))
         if testresults:
             self.testdatamodel.testresults = testresults
-            msg = self.testdatamodel.summary()
+            msg = self.testdatamodel.summary()  # TODO: Remove?
             self.status_label.setText(msg)
+        self.replace_pending_with_not_run()
         self.sig_finished.emit()
+
+    def replace_pending_with_not_run(self):
+        """Change status of pending tests to 'not run''."""
+        new_results = []
+        for res in self.testdatamodel.testresults:
+            if res.category == Category.PENDING:
+                new_res = copy.copy(res)
+                new_res.category = Category.SKIP
+                new_res.status = _('not run')
+                new_results.append(new_res)
+        if new_results:
+            self.testdatamodel.update_testresults(new_results)
 
     def tests_collected(self, testnames):
         """Called when tests are collected."""

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -232,6 +232,7 @@ class UnitTestWidget(QWidget):
             config.framework, self, tempfilename)
         self.testrunner.sig_finished.connect(self.process_finished)
         self.testrunner.sig_collected.connect(self.tests_collected)
+        self.testrunner.sig_collecterror.connect(self.tests_collect_error)
         self.testrunner.sig_starttest.connect(self.tests_started)
         self.testrunner.sig_testresult.connect(self.tests_yield_result)
 
@@ -303,11 +304,19 @@ class UnitTestWidget(QWidget):
         self.testdatamodel.add_testresults(testresults)
 
     def tests_started(self, testnames):
-        """Called when tests are about to be run.s are collected."""
+        """Called when tests are about to be run."""
         testresults = [TestResult(Category.PENDING, _('pending'), name,
                                   message=_('running'))
                        for name in testnames]
         self.testdatamodel.update_testresults(testresults)
+
+    def tests_collect_error(self, testnames_plus_msg):
+        """Called when errors are encountered during collection."""
+        testresults = [TestResult(Category.FAIL, _('failure'), name,
+                                  message=_('collection error'),
+                                  extra_text=msg)
+                       for name, msg in testnames_plus_msg]
+        self.testdatamodel.add_testresults(testresults)
 
     def tests_yield_result(self, testresults):
         """Called when test results are received."""

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -296,18 +296,17 @@ class UnitTestWidget(QWidget):
             self.status_label.setText(msg)
         self.sig_finished.emit()
 
-    def tests_collected(self, testdetails):
+    def tests_collected(self, testnames):
         """Called when tests are collected."""
-        testresults = [TestResult(Category.PENDING, _('pending'), detail.name,
-                                  detail.module)
-                       for detail in testdetails]
+        testresults = [TestResult(Category.PENDING, _('pending'), name)
+                       for name in testnames]
         self.testdatamodel.add_testresults(testresults)
 
-    def tests_started(self, testdetails):
+    def tests_started(self, testnames):
         """Called when tests are about to be run.s are collected."""
-        testresults = [TestResult(Category.PENDING, _('pending'), detail.name,
-                                  detail.module, message=_('running'))
-                       for detail in testdetails]
+        testresults = [TestResult(Category.PENDING, _('pending'), name,
+                                  message=_('running'))
+                       for name in testnames]
         self.testdatamodel.update_testresults(testresults)
 
     def tests_yield_result(self, testresults):

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -294,8 +294,6 @@ class UnitTestWidget(QWidget):
         self.log_action.setEnabled(bool(output))
         if testresults:
             self.testdatamodel.testresults = testresults
-            msg = self.testdatamodel.summary()  # TODO: Remove?
-            self.status_label.setText(msg)
         self.replace_pending_with_not_run()
         self.sig_finished.emit()
 


### PR DESCRIPTION
This PR implements the proper handling of errors encountered by py.test while it collects the tests, for example syntax errors in a test file.

A complication is that these errors are reported (and should be displayed by) with the module name, but not with the test name. This is resolved by a change in design: instead of `TestDetails`, which contains both module and test name, every line in the test results table is associated with just a `str`.

Fixes #93.