### PR TITLE
Implement go to test definition for py.test

### DIFF
--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -148,5 +148,6 @@ def logreport_to_testresult(report):
             extra_text += '----- {} -----\n'.format(heading)
             extra_text += text
     result = TestResult(cat, status, testname, message=message,
-                        time=duration, extra_text=extra_text)
+                        time=duration, extra_text=extra_text,
+                        filename=report['filename'], lineno=report['lineno'])
     return result

--- a/spyder_unittest/backend/pytestworker.py
+++ b/spyder_unittest/backend/pytestworker.py
@@ -73,13 +73,14 @@ class SpyderPlugin():
         """Called by py.test when a (phase of a) test is completed."""
         if report.when in ['setup', 'teardown'] and report.outcome == 'passed':
             return
-        # print(report.__dict__)
         data = {'event': 'logreport',
                 'when': report.when,
                 'outcome': report.outcome,
                 'nodeid': report.nodeid,
                 'sections': report.sections,
-                'duration': report.duration}
+                'duration': report.duration,
+                'filename': report.location[0],
+                'lineno': report.location[1]}
         if report.longrepr:
             if isinstance(report.longrepr, tuple):
                 data['longrepr'] = report.longrepr

--- a/spyder_unittest/backend/runnerbase.py
+++ b/spyder_unittest/backend/runnerbase.py
@@ -34,7 +34,7 @@ class TestResult:
     """Class representing the result of running a single test."""
 
     def __init__(self, category, status, name, message='', time=None,
-                 extra_text=''):
+                 extra_text='', filename=None, lineno=None):
         """
         Construct a test result.
 
@@ -46,6 +46,8 @@ class TestResult:
         message : str
         time : float or None
         extra_text : str
+        filename : str or None
+        lineno : int or None
         """
         self.category = category
         self.status = status
@@ -57,6 +59,8 @@ class TestResult:
             self.extra_text = extra_text.split("\n")
         else:
             self.extra_text = []
+        self.filename = filename
+        self.lineno = lineno
 
     def __eq__(self, other):
         """Test for equality."""

--- a/spyder_unittest/backend/tests/test_pytestrunner.py
+++ b/spyder_unittest/backend/tests/test_pytestrunner.py
@@ -121,97 +121,76 @@ def test_pytestrunner_process_output_with_starttest(qtbot):
     expected = ['ham.spam.ham', 'ham.eggs.bacon']
     assert blocker.args == [expected]
 
-def test_pytestrunner_process_output_with_logreport_passed(qtbot):
-    runner = PyTestRunner(None)
-    output = [{
+def standard_logreport_output():
+    return {
         'event': 'logreport',
         'when': 'call',
         'outcome': 'passed',
         'nodeid': 'foo.py::bar',
+        'filename': 'foo.py',
+        'lineno': 24,
         'duration': 42
-    }]
+    }
+
+def test_pytestrunner_process_output_with_logreport_passed(qtbot):
+    runner = PyTestRunner(None)
+    output = [standard_logreport_output()]
     with qtbot.waitSignal(runner.sig_testresult) as blocker:
         runner.process_output(output)
-    expected = [TestResult(Category.OK, 'ok', 'foo.bar', time=42)]
+    expected = [TestResult(Category.OK, 'ok', 'foo.bar', time=42,
+                           filename='foo.py', lineno=24)]
     assert blocker.args == [expected]
 
 def test_logreport_to_testresult_passed():
-    report = {
-        'event': 'logreport',
-        'when': 'call',
-        'outcome': 'passed',
-        'nodeid': 'foo.py::bar',
-        'duration': 42
-    }
-    expected = TestResult(Category.OK, 'ok', 'foo.bar', time=42)
+    report = standard_logreport_output()
+    expected = TestResult(Category.OK, 'ok', 'foo.bar', time=42,
+                          filename='foo.py', lineno=24)
     assert logreport_to_testresult(report) == expected
 
 def test_logreport_to_testresult_failed():
-    report = {
-        'event': 'logreport',
-        'when': 'call',
-        'outcome': 'failed',
-        'nodeid': 'foo.py::bar',
-        'duration': 42,
-        'message': 'msg',
-        'longrepr': 'exception text'
-    }
+    report = standard_logreport_output()
+    report['outcome'] = 'failed'
+    report['message'] = 'msg'
+    report['longrepr'] = 'exception text'
     expected = TestResult(Category.FAIL, 'failure', 'foo.bar',
-                          message='msg', time=42, extra_text='exception text')
+                          message='msg', time=42, extra_text='exception text',
+                          filename='foo.py', lineno=24)
     assert logreport_to_testresult(report) == expected
 
 def test_logreport_to_testresult_skipped():
-    report = {
-        'event': 'logreport',
-        'when': 'setup',
-        'outcome': 'skipped',
-        'nodeid': 'foo.py::bar',
-        'duration': 42,
-        'longrepr': ['file', 24, 'skipmsg']
-    }
+    report = standard_logreport_output()
+    report['when'] = 'setup'
+    report['outcome'] = 'skipped'
+    report['longrepr'] = ['file', 24, 'skipmsg']
     expected = TestResult(Category.SKIP, 'skipped', 'foo.bar',
-                          time=42, extra_text='skipmsg')
+                          time=42, extra_text='skipmsg', filename='foo.py',
+                          lineno=24)
     assert logreport_to_testresult(report) == expected
 
 def test_logreport_to_testresult_xfail():
-    report = {
-        'event': 'logreport',
-        'when': 'call',
-        'outcome': 'skipped',
-        'nodeid': 'foo.py::bar',
-        'duration': 42,
-        'message': 'msg',
-        'longrepr': 'exception text',
-        'wasxfail': ''
-    }
+    report = standard_logreport_output()
+    report['outcome'] = 'skipped'
+    report['message'] = 'msg'
+    report['longrepr'] = 'exception text'
+    report['wasxfail'] = ''
     expected = TestResult(Category.SKIP, 'skipped', 'foo.bar',
-                          message='msg', time=42, extra_text='exception text')
+                          message='msg', time=42, extra_text='exception text',
+                          filename='foo.py', lineno=24)
     assert logreport_to_testresult(report) == expected
 
 def test_logreport_to_testresult_xpass():
-    report = {
-        'event': 'logreport',
-        'when': 'call',
-        'outcome': 'passed',
-        'nodeid': 'foo.py::bar',
-        'duration': 42,
-        'wasxfail': ''
-    }
-    expected = TestResult(Category.OK, 'ok', 'foo.bar', time=42)
+    report = standard_logreport_output()
+    report['wasxfail'] = ''
+    expected = TestResult(Category.OK, 'ok', 'foo.bar', time=42,
+                          filename='foo.py', lineno=24)
     assert logreport_to_testresult(report) == expected
 
 def test_logreport_to_testresult_with_output():
-    report = {
-        'event': 'logreport',
-        'when': 'call',
-        'outcome': 'passed',
-        'nodeid': 'foo.py::bar',
-        'duration': 42,
-        'sections': [['Captured stdout call', 'ham\n'],
-                     ['Captured stderr call', 'spam\n']],
-    }
+    report = standard_logreport_output()
+    report['sections'] = [['Captured stdout call', 'ham\n'],
+                          ['Captured stderr call', 'spam\n']]
     txt = ('----- Captured stdout call -----\nham\n'
            '----- Captured stderr call -----\nspam\n')
     expected = TestResult(Category.OK, 'ok', 'foo.bar', time=42,
-                          extra_text=txt)
+                          extra_text=txt, filename='foo.py', lineno=24)
     assert logreport_to_testresult(report) == expected

--- a/spyder_unittest/backend/tests/test_pytestworker.py
+++ b/spyder_unittest/backend/tests/test_pytestworker.py
@@ -70,6 +70,7 @@ def standard_logreport():
     report.duration = 42
     report.sections = []
     report.longrepr = ''
+    report.location = ('foo.py', 24, 'bar')
     return report
 
 def test_spyderplugin_runtest_logreport(plugin):
@@ -81,7 +82,9 @@ def test_spyderplugin_runtest_logreport(plugin):
         'outcome': 'passed',
         'nodeid': 'foo.py::bar',
         'duration': 42,
-        'sections': []
+        'sections': [],
+        'filename': 'foo.py',
+        'lineno': 24
     })
 
 def test_spyderplugin_runtest_logreport_passes_longrepr(plugin):
@@ -95,6 +98,8 @@ def test_spyderplugin_runtest_logreport_passes_longrepr(plugin):
         'nodeid': 'foo.py::bar',
         'duration': 42,
         'sections': [],
+        'filename': 'foo.py',
+        'lineno': 24,
         'longrepr': '15'
     })
 
@@ -109,6 +114,8 @@ def test_spyderplugin_runtest_logreport_with_longrepr_tuple(plugin):
         'nodeid': 'foo.py::bar',
         'duration': 42,
         'sections': [],
+        'filename': 'foo.py',
+        'lineno': 24,
         'longrepr': ('ham', 'spam')
     })
 
@@ -123,6 +130,8 @@ def test_spyderplugin_runtest_logreport_passes_wasxfail(plugin):
         'nodeid': 'foo.py::bar',
         'duration': 42,
         'sections': [],
+        'filename': 'foo.py',
+        'lineno': 24,
         'wasxfail': ''
     })
 
@@ -144,10 +153,11 @@ def test_spyderplugin_runtest_logreport_passes_message(plugin):
         'nodeid': 'foo.py::bar',
         'duration': 42,
         'sections': [],
+        'filename': 'foo.py',
+        'lineno': 24,
         'longrepr': 'text',
         'message': 'msg'
     })
-
 
 def test_spyderplugin_runtest_logreport_ignores_teardown_passed(plugin):
     report = standard_logreport()
@@ -203,6 +213,8 @@ def test_pytestworker_integration(monkeypatch, tmpdir):
     assert args[3][0][0]['outcome'] == 'passed'
     assert args[3][0][0]['nodeid'] == 'test_foo.py::test_ok'
     assert args[3][0][0]['sections'] == []
+    assert args[3][0][0]['filename'] == 'test_foo.py'
+    assert args[3][0][0]['lineno'] == 0
     assert 'duration' in args[3][0][0]
 
     assert args[4][0][0]['event'] == 'starttest'
@@ -213,6 +225,8 @@ def test_pytestworker_integration(monkeypatch, tmpdir):
     assert args[5][0][0]['outcome'] == 'failed'
     assert args[5][0][0]['nodeid'] == 'test_foo.py::test_fail'
     assert args[5][0][0]['sections'] == []
+    assert args[5][0][0]['filename'] == 'test_foo.py'
+    assert args[5][0][0]['lineno'] == 1
     assert 'duration' in args[5][0][0]
 
     assert args[6][0][0]['event'] == 'finished'

--- a/spyder_unittest/tests/test_unittestplugin.py
+++ b/spyder_unittest/tests/test_unittestplugin.py
@@ -116,8 +116,13 @@ def test_plugin_config(plugin, tmpdir, qtbot):
     plugin.handle_project_change()
     assert plugin.unittestwidget.config is None
 
-    # Re-open project and test that config is correctly read    
+    # Re-open project and test that config is correctly read
     plugin.main.projects.get_active_project = lambda: project
     plugin.main.projects.get_active_project_path = lambda: project.root_path
     plugin.handle_project_change()
     assert plugin.unittestwidget.config == config
+
+
+def test_plugin_goto_in_editor(plugin, qtbot):
+    plugin.unittestwidget.sig_edit_goto.emit('somefile', 42)
+    plugin.main.editor.load.assert_called_with('somefile', 43, '')

--- a/spyder_unittest/unittestplugin.py
+++ b/spyder_unittest/unittestplugin.py
@@ -139,6 +139,16 @@ class UnitTestPlugin(SpyderPluginWidget):
         project_conf.set(self.CONF_SECTION, 'framework', test_config.framework)
         project_conf.set(self.CONF_SECTION, 'wdir', test_config.wdir)
 
+    def goto_in_editor(self, filename, lineno):
+        """
+        Go to specified line in editor.
+
+        This function is called when the unittest widget emits `sig_edit_goto`.
+        Note that the line number in the signal is zero based (the first line
+        is line 0), but the editor expects a one-based line number.
+        """
+        self.main.editor.load(filename, lineno + 1, '')
+
 # ----- SpyderPluginWidget API --------------------------------------------
 
     def get_plugin_title(self):
@@ -179,6 +189,7 @@ class UnitTestPlugin(SpyderPluginWidget):
         self.main.projects.sig_project_closed.connect(
             self.handle_project_change)
         self.unittestwidget.sig_newconfig.connect(self.save_config)
+        self.unittestwidget.sig_edit_goto.connect(self.goto_in_editor)
 
         # Add plugin as dockwidget to main window
         self.main.add_dockwidget(self)

--- a/spyder_unittest/widgets/datatree.py
+++ b/spyder_unittest/widgets/datatree.py
@@ -105,8 +105,11 @@ class TestDataView(QTreeView):
     def go_to_test_definition(self, index):
         """Ask editor to go to definition of test corresponding to index."""
         index = self.make_index_canonical(index)
-        test_location = self.model().data(index, Qt.UserRole)
-        self.sig_edit_goto.emit(*test_location)
+        filename, lineno = self.model().data(index, Qt.UserRole)
+        if filename is not None:
+            if lineno is None:
+                lineno = 0
+            self.sig_edit_goto.emit(filename, lineno)
 
     def make_index_canonical(self, index):
         """
@@ -134,10 +137,10 @@ class TestDataView(QTreeView):
                                      triggered=lambda: self.expand(index))
             menuItem.setEnabled(self.model().hasChildren(index))
         contextMenu.addAction(menuItem)
-        test_location = self.model().data(index, Qt.UserRole)
         menuItem = create_action(
                 self, _('Go to definition'),
-                triggered=lambda: self.sig_edit_goto.emit(*test_location))
+                triggered=lambda: self.go_to_test_definition(index))
+        test_location = self.model().data(index, Qt.UserRole)
         menuItem.setEnabled(test_location[0] is not None)
         contextMenu.addAction(menuItem)
         return contextMenu

--- a/spyder_unittest/widgets/datatree.py
+++ b/spyder_unittest/widgets/datatree.py
@@ -12,8 +12,9 @@ from collections import Counter
 from qtpy import PYQT4
 from qtpy.QtCore import QAbstractItemModel, QModelIndex, Qt, Signal
 from qtpy.QtGui import QBrush, QColor, QFont
-from qtpy.QtWidgets import QTreeView
+from qtpy.QtWidgets import QMenu, QTreeView
 from spyder.config.base import get_translation
+from spyder.utils.qthelpers import create_action
 
 # Local imports
 from spyder_unittest.backend.abbreviator import Abbreviator
@@ -80,6 +81,14 @@ class TestDataView(QTreeView):
         while bottomRight.parent().isValid():
             bottomRight = bottomRight.parent()
         self.spanFirstColumn(topLeft.row(), bottomRight.row())
+
+    def contextMenuEvent(self, event):
+        """Called when user requests a context menu."""
+        contextMenu = QMenu(self)
+        menuItem = create_action(self, _('Do nothing'),
+                                 triggered=lambda: None)
+        contextMenu.addAction(menuItem)
+        contextMenu.exec_(event.globalPos())
 
     def resizeColumns(self):
         """Resize column to fit their contents."""

--- a/spyder_unittest/widgets/tests/test_datatree.py
+++ b/spyder_unittest/widgets/tests/test_datatree.py
@@ -6,12 +6,98 @@
 """Tests for unittestgui.py."""
 
 # Third party imports
-from qtpy.QtCore import Qt
+from qtpy.QtCore import QModelIndex, QPoint, Qt
+from qtpy.QtGui import QContextMenuEvent
+import pytest
 
 # Local imports
 from spyder_unittest.backend.runnerbase import Category, TestResult
-from spyder_unittest.widgets.datatree import COLORS, TestDataModel
+from spyder_unittest.widgets.datatree import (COLORS, TestDataModel,
+                                              TestDataView)
 
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock  # Python 2
+
+
+@pytest.fixture
+def view_and_model(qtbot):
+    view = TestDataView()
+    model = TestDataModel()
+    res = [TestResult(Category.OK, 'status', 'foo.bar'),
+           TestResult(Category.FAIL, 'error', 'foo.bar', 'kadoom', 0,
+                      'crash!\nboom!', filename='ham.py', lineno=42)]
+    model.testresults = res
+    view.setModel(model)
+    return view, model
+
+def test_contextMenuEvent_calls_exec(view_and_model, monkeypatch):
+    # test that a menu is displayed when clicking on an item
+    mock_exec = Mock()
+    monkeypatch.setattr('spyder_unittest.widgets.datatree.QMenu.exec_', mock_exec)
+    view, model = view_and_model
+    pos = view.visualRect(model.index(0, 0)).center()
+    event = QContextMenuEvent(QContextMenuEvent.Mouse, pos)
+    view.contextMenuEvent(event)
+    assert mock_exec.called
+
+    # test that no menu is displayed when clicking below the bottom item
+    mock_exec.reset_mock()
+    pos = view.visualRect(model.index(1, 0)).bottomRight()
+    pos += QPoint(0, 1)
+    event = QContextMenuEvent(QContextMenuEvent.Mouse, pos)
+    view.contextMenuEvent(event)
+    assert not mock_exec.called
+
+def test_go_to_test_definition(view_and_model, qtbot):
+    view, model = view_and_model
+    with qtbot.waitSignal(view.sig_edit_goto) as blocker:
+        view.go_to_test_definition(model.index(1, 0))
+    assert blocker.args == ['ham.py', 42]
+
+def test_make_index_canonical_with_index_in_column2(view_and_model):
+    view, model = view_and_model
+    index = model.index(1, 2)
+    res = view.make_index_canonical(index)
+    assert res == model.index(1, 0)
+
+def test_make_index_canonical_with_level2_index(view_and_model):
+    view, model = view_and_model
+    index = model.index(1, 0, model.index(1, 0))
+    res = view.make_index_canonical(index)
+    assert res == model.index(1, 0)
+
+def test_make_index_canonical_with_invalid_index(view_and_model):
+    view, model = view_and_model
+    index = QModelIndex()
+    res = view.make_index_canonical(index)
+    assert res is None
+
+def test_build_context_menu(view_and_model):
+    view, model = view_and_model
+    menu = view.build_context_menu(model.index(0, 0))
+    assert menu.actions()[0].text() == 'Expand'
+    assert menu.actions()[1].text() == 'Go to definition'
+
+def test_build_context_menu_with_disabled_entries(view_and_model):
+    view, model = view_and_model
+    menu = view.build_context_menu(model.index(0, 0))
+    assert menu.actions()[0].isEnabled() == False
+    assert menu.actions()[1].isEnabled() == False
+
+def test_build_context_menu_with_enabled_entries(view_and_model):
+    view, model = view_and_model
+    menu = view.build_context_menu(model.index(1, 0))
+    assert menu.actions()[0].isEnabled() == True
+    assert menu.actions()[1].isEnabled() == True
+
+def test_build_context_menu_with_expanded_entry(view_and_model):
+    view, model = view_and_model
+    view.expand(model.index(1, 0))
+    menu = view.build_context_menu(model.index(1, 0))
+    assert menu.actions()[0].text() == 'Collapse'
+    assert menu.actions()[0].isEnabled() == True
 
 def test_testdatamodel_using_qtmodeltester(qtmodeltester):
     model = TestDataModel()

--- a/spyder_unittest/widgets/tests/test_datatree.py
+++ b/spyder_unittest/widgets/tests/test_datatree.py
@@ -21,7 +21,6 @@ def test_testdatamodel_using_qtmodeltester(qtmodeltester):
     model.testresults = res
     qtmodeltester.check(model)
 
-
 def test_testdatamodel_shows_abbreviated_name_in_table(qtbot):
     model = TestDataModel()
     res = TestResult(Category.OK, 'status', 'foo.bar', '', 0, '')
@@ -29,14 +28,12 @@ def test_testdatamodel_shows_abbreviated_name_in_table(qtbot):
     index = model.index(0, 1)
     assert model.data(index, Qt.DisplayRole) == 'f.bar'
 
-
 def test_testdatamodel_shows_full_name_in_tooltip(qtbot):
     model = TestDataModel()
     res = TestResult(Category.OK, 'status', 'foo.bar', '', 0, '')
     model.testresults = [res]
     index = model.index(0, 1)
     assert model.data(index, Qt.ToolTipRole) == 'foo.bar'
-
 
 def test_testdatamodel_data_background():
     model = TestDataModel()
@@ -48,6 +45,13 @@ def test_testdatamodel_data_background():
     index = model.index(1, 2)
     assert model.data(index, Qt.BackgroundRole) == COLORS[Category.FAIL]
 
+def test_testdatamodel_data_userrole():
+    model = TestDataModel()
+    res = [TestResult(Category.OK, 'status', 'foo.bar', filename='somefile',
+                      lineno=42)]
+    model.testresults = res
+    index = model.index(0, 0)
+    assert model.data(index, Qt.UserRole) == ('somefile', 42)
 
 def test_testdatamodel_add_tests(qtbot):
     def check_args1(parent, begin, end):

--- a/spyder_unittest/widgets/tests/test_datatree.py
+++ b/spyder_unittest/widgets/tests/test_datatree.py
@@ -50,11 +50,25 @@ def test_contextMenuEvent_calls_exec(view_and_model, monkeypatch):
     view.contextMenuEvent(event)
     assert not mock_exec.called
 
-def test_go_to_test_definition(view_and_model, qtbot):
+def test_go_to_test_definition_with_invalid_target(view_and_model, qtbot):
+    view, model = view_and_model
+    with qtbot.assertNotEmitted(view.sig_edit_goto):
+        view.go_to_test_definition(model.index(0, 0))
+
+def test_go_to_test_definition_with_valid_target(view_and_model, qtbot):
     view, model = view_and_model
     with qtbot.waitSignal(view.sig_edit_goto) as blocker:
         view.go_to_test_definition(model.index(1, 0))
     assert blocker.args == ['ham.py', 42]
+
+def test_go_to_test_definition_with_lineno_none(view_and_model, qtbot):
+    view, model = view_and_model
+    res = model.testresults
+    res[1].lineno = None
+    model.testresults = res
+    with qtbot.waitSignal(view.sig_edit_goto) as blocker:
+        view.go_to_test_definition(model.index(1, 0))
+    assert blocker.args == ['ham.py', 0]
 
 def test_make_index_canonical_with_index_in_column2(view_and_model):
     view, model = view_and_model

--- a/spyder_unittest/widgets/tests/test_unittestgui.py
+++ b/spyder_unittest/widgets/tests/test_unittestgui.py
@@ -9,7 +9,6 @@
 import os
 
 # Third party imports
-from pytestqt import qtbot
 from qtpy.QtCore import Qt
 import pytest
 
@@ -24,7 +23,14 @@ except ImportError:
     from mock import Mock  # Python 2
 
 
-def test_unittestgui_set_config_emits_newconfig(qtbot):
+def test_unittestwidget_forwards_sig_edit_goto(qtbot):
+    widget = UnitTestWidget(None)
+    qtbot.addWidget(widget)
+    with qtbot.waitSignal(widget.sig_edit_goto) as blocker:
+        widget.testdataview.sig_edit_goto.emit('ham', 42)
+    assert blocker.args == ['ham', 42]
+
+def test_unittestwidget_set_config_emits_newconfig(qtbot):
     widget = UnitTestWidget(None)
     qtbot.addWidget(widget)
     config = Config(wdir=os.getcwd(), framework='unittest')
@@ -33,7 +39,7 @@ def test_unittestgui_set_config_emits_newconfig(qtbot):
     assert blocker.args == [config]
     assert widget.config == config
 
-def test_unittestgui_set_config_does_not_emit_when_invalid(qtbot):
+def test_unittestwidget_set_config_does_not_emit_when_invalid(qtbot):
     widget = UnitTestWidget(None)
     qtbot.addWidget(widget)
     config = Config(wdir=os.getcwd(), framework=None)

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -64,12 +64,15 @@ class UnitTestWidget(QWidget):
     sig_finished: Emitted when plugin finishes processing tests.
     sig_newconfig(Config): Emitted when test config is changed.
         Argument is new config, which is always valid.
+    sig_edit_goto(str, int): Emitted if editor should go to some position.
+        Arguments are file name and line number (zero-based).
     """
 
     VERSION = '0.0.1'
 
     sig_finished = Signal()
     sig_newconfig = Signal(Config)
+    sig_edit_goto = Signal(str, int)
 
     def __init__(self, parent, options_button=None, options_menu=None):
         """Unit testing widget."""
@@ -85,6 +88,7 @@ class UnitTestWidget(QWidget):
         self.testdataview = TestDataView(self)
         self.testdatamodel = TestDataModel(self)
         self.testdataview.setModel(self.testdatamodel)
+        self.testdataview.sig_edit_goto.connect(self.sig_edit_goto)
         self.testdatamodel.sig_summary.connect(self.set_status_label)
 
         self.framework_registry = FrameworkRegistry()


### PR DESCRIPTION
This PR implements a way for the user to go to the definition of a test. Specifically, we record the location of the tests as recorded by py.test (this feature is not yet implemented for unittest and nose). When the user double clicks on a test, the editor will go the test definition. When the uer right-clicks, a context menu appears with two items: "expand" for expanding the test results in the tree and "go to definition" for going to the test definition. If the test is already expanses, then "expand" is replaced by "collapse". This context menu will help with #88.

Fixes #12. 