### PR TITLE
Use nodeid when collecting tests using py.test

### DIFF
--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -58,10 +58,11 @@ class PyTestRunner(RunnerBase):
 
         for result_item in output:
             if result_item['event'] == 'collected':
-                collected_list.append(logreport_collected_to_str(result_item))
+                testname = convert_nodeid_to_testname(result_item['nodeid'])
+                collected_list.append(testname)
             elif result_item['event'] == 'collecterror':
-                collecterror_list.append(
-                        logreport_collecterror_to_tuple(result_item))
+                tupl = logreport_collecterror_to_tuple(result_item)
+                collecterror_list.append(tupl)
             elif result_item['event'] == 'starttest':
                 starttest_list.append(logreport_starttest_to_str(result_item))
             elif result_item['event'] == 'logreport':
@@ -104,12 +105,6 @@ def convert_nodeid_to_testname(nodeid):
     module, name = nodeid.split('::', 1)
     module = normalize_module_name(module)
     return '{}.{}'.format(module, name)
-
-
-def logreport_collected_to_str(report):
-    """Convert a 'collected' logreport to a str."""
-    module = normalize_module_name(report['module'])
-    return '{}.{}'.format(module, report['name'])
 
 
 def logreport_collecterror_to_tuple(report):

--- a/spyder_unittest/backend/pytestworker.py
+++ b/spyder_unittest/backend/pytestworker.py
@@ -56,10 +56,14 @@ class SpyderPlugin():
 
     def pytest_itemcollected(self, item):
         """Called by py.test when a test item is collected."""
+        nodeid = item.name
+        x = item.parent
+        while x.parent:
+            nodeid = x.name + '::' + nodeid
+            x = x.parent
         self.writer.write({
             'event': 'collected',
-            'name': item.name,
-            'module': item.parent.name
+            'nodeid': nodeid
         })
 
     def pytest_runtest_logstart(self, nodeid, location):

--- a/spyder_unittest/backend/tests/test_pytestrunner.py
+++ b/spyder_unittest/backend/tests/test_pytestrunner.py
@@ -86,15 +86,8 @@ def test_pytestrunner_read_output(monkeypatch):
 
 def test_pytestrunner_process_output_with_collected(qtbot):
     runner = PyTestRunner(None)
-    output = [{
-        'event': 'collected',
-        'module': 'spam.py',
-        'name': 'ham'
-    }, {
-        'event': 'collected',
-        'module': 'eggs.py',
-        'name': 'bacon'
-    }]
+    output = [{'event': 'collected', 'nodeid': 'spam.py::ham'},
+              {'event': 'collected', 'nodeid': 'eggs.py::bacon'}]
     with qtbot.waitSignal(runner.sig_collected) as blocker:
         runner.process_output(output)
     expected = ['spam.ham', 'eggs.bacon']

--- a/spyder_unittest/backend/tests/test_pytestworker.py
+++ b/spyder_unittest/backend/tests/test_pytestworker.py
@@ -52,14 +52,16 @@ def test_spyderplugin_test_collectreport_with_failure(plugin):
 
 def test_spyderplugin_test_itemcollected(plugin):
     testitem = EmptyClass()
-    testitem.name = 'foo'
+    testitem.name = 'bar'
     testitem.parent = EmptyClass()
-    testitem.parent.name = 'bar.py'
+    testitem.parent.name = 'foo.py'
+    testitem.parent.parent = EmptyClass
+    testitem.parent.parent.name = 'notused'
+    testitem.parent.parent.parent = None
     plugin.pytest_itemcollected(testitem)
     plugin.writer.write.assert_called_once_with({
         'event': 'collected',
-        'name': 'foo',
-        'module': 'bar.py'
+        'nodeid': 'foo.py::bar'
     })
 
 def standard_logreport():
@@ -198,12 +200,10 @@ def test_pytestworker_integration(monkeypatch, tmpdir):
     args = mock_writer.write.call_args_list
 
     assert args[0][0][0]['event'] == 'collected'
-    assert args[0][0][0]['name'] == 'test_ok'
-    assert args[0][0][0]['module'] == 'test_foo.py'
+    assert args[0][0][0]['nodeid'] == 'test_foo.py::test_ok'
 
     assert args[1][0][0]['event'] == 'collected'
-    assert args[1][0][0]['name'] == 'test_fail'
-    assert args[1][0][0]['module'] == 'test_foo.py'
+    assert args[1][0][0]['nodeid'] == 'test_foo.py::test_fail'
 
     assert args[2][0][0]['event'] == 'starttest'
     assert args[2][0][0]['nodeid'] == 'test_foo.py::test_ok'


### PR DESCRIPTION
This is more robust, because nodeid's are also used when processing the test reports. In particular, this fixes a bug which prevented the plugin to work correctly with test functions which are defined within a class.

Fixes #98 .