### PR TITLE
Allow user to sort tests

### DIFF
--- a/spyder_unittest/backend/runnerbase.py
+++ b/spyder_unittest/backend/runnerbase.py
@@ -24,8 +24,8 @@ except ImportError:  # Python 2
 class Category:
     """Enum type representing category of test result."""
 
-    OK = 1
-    FAIL = 2
+    FAIL = 1
+    OK = 2
     SKIP = 3
     PENDING = 4
 

--- a/spyder_unittest/widgets/datatree.py
+++ b/spyder_unittest/widgets/datatree.py
@@ -7,6 +7,7 @@
 
 # Standard library imports
 from collections import Counter
+from operator import attrgetter
 
 # Third party imports
 from qtpy import PYQT4
@@ -358,8 +359,22 @@ class TestDataModel(QAbstractItemModel):
             return 1
 
     def sort(self, column, order):
-        """Sort model by column in order."""
-        print('in sort(): column =', column, 'order =', order)
+        """Sort model by `column` in `order`."""
+        def key_time(result):
+            return result.time or -1
+
+        reverse = order == Qt.DescendingOrder
+        if column == STATUS_COLUMN:
+            self.testresults.sort(key=attrgetter('category', 'status'),
+                                  reverse=reverse)
+        elif column == NAME_COLUMN:
+            self.testresults.sort(key=attrgetter('name'), reverse=reverse)
+        elif column == MESSAGE_COLUMN:
+            self.testresults.sort(key=attrgetter('message'), reverse=reverse)
+        elif column == TIME_COLUMN:
+            self.testresults.sort(key=key_time, reverse=reverse)
+        self.dataChanged.emit(self.index(0, 0),
+                              self.index(len(self.testresults), len(HEADERS)))
 
     def summary(self):
         """Return summary for current results."""

--- a/spyder_unittest/widgets/datatree.py
+++ b/spyder_unittest/widgets/datatree.py
@@ -60,7 +60,11 @@ class TestDataView(QTreeView):
         QTreeView.__init__(self, parent)
         self.header().setDefaultAlignment(Qt.AlignCenter)
         self.setItemsExpandable(True)
-        self.setSortingEnabled(False)
+        self.setSortingEnabled(True)
+        self.header().setSortIndicatorShown(False)
+        self.header().sortIndicatorChanged.connect(self.sortByColumn)
+        self.header().sortIndicatorChanged.connect(
+                lambda col, order: self.header().setSortIndicatorShown(True))
         self.setExpandsOnDoubleClick(False)
         self.doubleClicked.connect(self.go_to_test_definition)
 
@@ -352,6 +356,10 @@ class TestDataModel(QAbstractItemModel):
             return len(HEADERS)
         else:
             return 1
+
+    def sort(self, column, order):
+        """Sort model by column in order."""
+        print('in sort(): column =', column, 'order =', order)
 
     def summary(self):
         """Return summary for current results."""

--- a/spyder_unittest/widgets/tests/test_datatree.py
+++ b/spyder_unittest/widgets/tests/test_datatree.py
@@ -205,7 +205,7 @@ STANDARD_TESTRESULTS = [
 
 def test_testdatamodel_sort_by_status_ascending(qtbot):
     model = TestDataModel()
-    model.testresults = STANDARD_TESTRESULTS.copy()
+    model.testresults = STANDARD_TESTRESULTS[:]
     with qtbot.waitSignal(model.dataChanged):
         model.sort(0, Qt.AscendingOrder)
     expected = [STANDARD_TESTRESULTS[k] for k in [2, 1, 0]]
@@ -213,28 +213,28 @@ def test_testdatamodel_sort_by_status_ascending(qtbot):
 
 def test_testdatamodel_sort_by_status_descending():
     model = TestDataModel()
-    model.testresults = STANDARD_TESTRESULTS.copy()
+    model.testresults = STANDARD_TESTRESULTS[:]
     model.sort(0, Qt.DescendingOrder)
     expected = [STANDARD_TESTRESULTS[k] for k in [0, 1, 2]]
     assert model.testresults == expected
 
 def test_testdatamodel_sort_by_name():
     model = TestDataModel()
-    model.testresults = STANDARD_TESTRESULTS.copy()
+    model.testresults = STANDARD_TESTRESULTS[:]
     model.sort(1, Qt.AscendingOrder)
     expected = [STANDARD_TESTRESULTS[k] for k in [0, 2, 1]]
     assert model.testresults == expected
 
 def test_testdatamodel_sort_by_message():
     model = TestDataModel()
-    model.testresults = STANDARD_TESTRESULTS.copy()
+    model.testresults = STANDARD_TESTRESULTS[:]
     model.sort(2, Qt.AscendingOrder)
     expected = [STANDARD_TESTRESULTS[k] for k in [0, 2, 1]]
     assert model.testresults == expected
 
 def test_testdatamodel_sort_by_time():
     model = TestDataModel()
-    model.testresults = STANDARD_TESTRESULTS.copy()
+    model.testresults = STANDARD_TESTRESULTS[:]
     model.sort(3, Qt.AscendingOrder)
     expected = [STANDARD_TESTRESULTS[k] for k in [2, 1, 0]]
     assert model.testresults == expected

--- a/spyder_unittest/widgets/tests/test_datatree.py
+++ b/spyder_unittest/widgets/tests/test_datatree.py
@@ -25,11 +25,12 @@ except ImportError:
 def view_and_model(qtbot):
     view = TestDataView()
     model = TestDataModel()
+    # setModel() before populating testresults because setModel() does a sort
+    view.setModel(model)
     res = [TestResult(Category.OK, 'status', 'foo.bar'),
            TestResult(Category.FAIL, 'error', 'foo.bar', 'kadoom', 0,
                       'crash!\nboom!', filename='ham.py', lineno=42)]
     model.testresults = res
-    view.setModel(model)
     return view, model
 
 def test_contextMenuEvent_calls_exec(view_and_model, monkeypatch):
@@ -196,3 +197,44 @@ def test_testdatamodel_replace_tests(qtbot):
                            raising=True):
         model.update_testresults([result2])
     assert model.testresults == [result2]
+
+STANDARD_TESTRESULTS = [
+    TestResult(Category.OK, 'status', 'foo.bar', time=2),
+    TestResult(Category.FAIL, 'failure', 'fu.baz', 'kaboom',time=1),
+    TestResult(Category.FAIL, 'error', 'fu.bar', 'boom')]
+
+def test_testdatamodel_sort_by_status_ascending(qtbot):
+    model = TestDataModel()
+    model.testresults = STANDARD_TESTRESULTS.copy()
+    with qtbot.waitSignal(model.dataChanged):
+        model.sort(0, Qt.AscendingOrder)
+    expected = [STANDARD_TESTRESULTS[k] for k in [0, 2, 1]]
+    assert model.testresults == expected
+
+def test_testdatamodel_sort_by_status_descending():
+    model = TestDataModel()
+    model.testresults = STANDARD_TESTRESULTS.copy()
+    model.sort(0, Qt.DescendingOrder)
+    expected = [STANDARD_TESTRESULTS[k] for k in [1, 2, 0]]
+    assert model.testresults == expected
+
+def test_testdatamodel_sort_by_name():
+    model = TestDataModel()
+    model.testresults = STANDARD_TESTRESULTS.copy()
+    model.sort(1, Qt.AscendingOrder)
+    expected = [STANDARD_TESTRESULTS[k] for k in [0, 2, 1]]
+    assert model.testresults == expected
+
+def test_testdatamodel_sort_by_message():
+    model = TestDataModel()
+    model.testresults = STANDARD_TESTRESULTS.copy()
+    model.sort(2, Qt.AscendingOrder)
+    expected = [STANDARD_TESTRESULTS[k] for k in [0, 2, 1]]
+    assert model.testresults == expected
+
+def test_testdatamodel_sort_by_time():
+    model = TestDataModel()
+    model.testresults = STANDARD_TESTRESULTS.copy()
+    model.sort(3, Qt.AscendingOrder)
+    expected = [STANDARD_TESTRESULTS[k] for k in [2, 1, 0]]
+    assert model.testresults == expected

--- a/spyder_unittest/widgets/tests/test_datatree.py
+++ b/spyder_unittest/widgets/tests/test_datatree.py
@@ -208,14 +208,14 @@ def test_testdatamodel_sort_by_status_ascending(qtbot):
     model.testresults = STANDARD_TESTRESULTS.copy()
     with qtbot.waitSignal(model.dataChanged):
         model.sort(0, Qt.AscendingOrder)
-    expected = [STANDARD_TESTRESULTS[k] for k in [0, 2, 1]]
+    expected = [STANDARD_TESTRESULTS[k] for k in [2, 1, 0]]
     assert model.testresults == expected
 
 def test_testdatamodel_sort_by_status_descending():
     model = TestDataModel()
     model.testresults = STANDARD_TESTRESULTS.copy()
     model.sort(0, Qt.DescendingOrder)
-    expected = [STANDARD_TESTRESULTS[k] for k in [1, 2, 0]]
+    expected = [STANDARD_TESTRESULTS[k] for k in [0, 1, 2]]
     assert model.testresults == expected
 
 def test_testdatamodel_sort_by_name():


### PR DESCRIPTION
Make the header clickable so that the user can click there to sort on that column. I envisage the main use is to quickly find failing tests if there are many tests: sort by status and failing tests are sorted to top.

Fixes #94 .