### PR TITLE
Improve display of test times

### DIFF
--- a/spyder_unittest/backend/unittestrunner.py
+++ b/spyder_unittest/backend/unittestrunner.py
@@ -57,7 +57,7 @@ class UnittestRunner(RunnerBase):
                     cat = Category.SKIP
                 name = '{}.{}'.format(data[1], data[0])
                 tr = TestResult(category=cat, status=data[2], name=name,
-                                message=data[3], time=0, extra_text='')
+                                message=data[3])
                 res.append(tr)
                 line_index += 1
                 test_index = -1

--- a/spyder_unittest/widgets/datatree.py
+++ b/spyder_unittest/widgets/datatree.py
@@ -290,7 +290,8 @@ class TestDataModel(QAbstractItemModel):
         If `role` is `TooltipRole`, then return string for tool tip.
         If `role` is `FontRole`, then return monospace font for level-2 items.
         If `role` is `BackgroundRole`, then return background color.
-        If `role` is `UserRole`, then return location of test as (file, line)
+        If `role` is `TextAlignmentRole`, then return right-aligned for time.
+        If `role` is `UserRole`, then return location of test as (file, line).
         """
         if not index.isValid():
             return None
@@ -319,6 +320,9 @@ class TestDataModel(QAbstractItemModel):
             if id == TOPLEVEL_ID:
                 testresult = self.testresults[row]
                 return COLORS[testresult.category]
+        elif role == Qt.TextAlignmentRole:
+            if id == TOPLEVEL_ID and column == TIME_COLUMN:
+                return Qt.AlignRight
         elif role == Qt.UserRole:
             if id == TOPLEVEL_ID:
                 testresult = self.testresults[row]

--- a/spyder_unittest/widgets/datatree.py
+++ b/spyder_unittest/widgets/datatree.py
@@ -308,7 +308,7 @@ class TestDataModel(QAbstractItemModel):
                 return self.testresults[row].message
             elif column == TIME_COLUMN:
                 time = self.testresults[row].time
-                return str(time * 1e3) if time else ''
+                return '{:.2f}'.format(time * 1e3) if time else ''
         elif role == Qt.ToolTipRole:
             if id == TOPLEVEL_ID and column == NAME_COLUMN:
                 return self.testresults[row].name

--- a/spyder_unittest/widgets/datatree.py
+++ b/spyder_unittest/widgets/datatree.py
@@ -309,7 +309,7 @@ class TestDataModel(QAbstractItemModel):
                 return self.testresults[row].message
             elif column == TIME_COLUMN:
                 time = self.testresults[row].time
-                return '{:.2f}'.format(time * 1e3) if time else ''
+                return '' if time is None else '{:.2f}'.format(time * 1e3)
         elif role == Qt.ToolTipRole:
             if id == TOPLEVEL_ID and column == NAME_COLUMN:
                 return self.testresults[row].name

--- a/spyder_unittest/widgets/tests/test_datatree.py
+++ b/spyder_unittest/widgets/tests/test_datatree.py
@@ -136,6 +136,13 @@ def test_testdatamodel_shows_full_name_in_tooltip(qtbot):
     index = model.index(0, 1)
     assert model.data(index, Qt.ToolTipRole) == 'foo.bar'
 
+def test_testdatamodel_shows_time(qtmodeltester):
+    model = TestDataModel()
+    res = TestResult(Category.OK, 'status', 'foo.bar', time=0.0012345)
+    model.testresults = [res]
+    index = model.index(0, 3)
+    assert model.data(index, Qt.DisplayRole) == '1.23'
+
 def test_testdatamodel_data_background():
     model = TestDataModel()
     res = [TestResult(Category.OK, 'status', 'foo.bar'),

--- a/spyder_unittest/widgets/tests/test_datatree.py
+++ b/spyder_unittest/widgets/tests/test_datatree.py
@@ -142,6 +142,7 @@ def test_testdatamodel_shows_time(qtmodeltester):
     model.testresults = [res]
     index = model.index(0, 3)
     assert model.data(index, Qt.DisplayRole) == '1.23'
+    assert model.data(index, Qt.TextAlignmentRole) == Qt.AlignRight
 
 def test_testdatamodel_data_background():
     model = TestDataModel()

--- a/spyder_unittest/widgets/tests/test_datatree.py
+++ b/spyder_unittest/widgets/tests/test_datatree.py
@@ -144,6 +144,18 @@ def test_testdatamodel_shows_time(qtmodeltester):
     assert model.data(index, Qt.DisplayRole) == '1.23'
     assert model.data(index, Qt.TextAlignmentRole) == Qt.AlignRight
 
+def test_testdatamodel_shows_time_when_zero(qtmodeltester):
+    model = TestDataModel()
+    res = TestResult(Category.OK, 'status', 'foo.bar', time=0)
+    model.testresults = [res]
+    assert model.data(model.index(0, 3), Qt.DisplayRole) == '0.00'
+
+def test_testdatamodel_shows_time_when_blank(qtmodeltester):
+    model = TestDataModel()
+    res = TestResult(Category.OK, 'status', 'foo.bar')
+    model.testresults = [res]
+    assert model.data(model.index(0, 3), Qt.DisplayRole) == ''
+
 def test_testdatamodel_data_background():
     model = TestDataModel()
     res = [TestResult(Category.OK, 'status', 'foo.bar'),


### PR DESCRIPTION
The plugin reports the times taken for each test. This PR displays the times rounded to the nearest 0.01 ms (instead of the ridiculous precision reported now) and aligns the numbers to the right (so that the decimal points are aligned). Do not display any times If the unittest framework is used, because it does not report the time.

Fixes #86. Fixes #87.