### PR TITLE
Use paler shade of red as background for failing tests

### DIFF
--- a/spyder_unittest/widgets/datatree.py
+++ b/spyder_unittest/widgets/datatree.py
@@ -29,7 +29,7 @@ except KeyError as error:
 
 COLORS = {
     Category.OK: QBrush(QColor("#C1FFBA")),
-    Category.FAIL: QBrush(QColor("#FF0000")),
+    Category.FAIL: QBrush(QColor("#FF5050")),
     Category.SKIP: QBrush(QColor("#C5C5C5")),
     Category.PENDING: QBrush(QColor("#C5C5C5"))
 }


### PR DESCRIPTION
This uses the same red which used in Spyder's find/replace widget for regexp errors.

Fixes #96.