### PR TITLE
Update Pypi description and README

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,7 @@
+The Spyder Project Contributors are composed of:
+
+* Pierre Raybaut <pierre.raybaut@gmail.com> (Original Spyder author).
+* Carlos Cordoba <ccordoba12@gmail.com> (Current maintainer).
+* All other developers who have contributed to this repository
+  and/or the precursor in the main spyder-ide/spyder repository.
+

--- a/README.md
+++ b/README.md
@@ -1,44 +1,51 @@
 # spyder-unittest
 
-## Project information
 [![license](https://img.shields.io/pypi/l/spyder-unittest.svg)](./LICENSE)
 [![pypi version](https://img.shields.io/pypi/v/spyder-unittest.svg)](https://pypi.python.org/pypi/spyder-unittest)
 [![Join the chat at https://gitter.im/spyder-ide/public](https://badges.gitter.im/spyder-ide/spyder.svg)](https://gitter.im/spyder-ide/public)
 [![OpenCollective Backers](https://opencollective.com/spyder/backers/badge.svg?color=blue)](#backers)
 [![OpenCollective Sponsors](https://opencollective.com/spyder/sponsors/badge.svg?color=blue)](#sponsors)
 
-## Build status
 [![Build Status](https://travis-ci.org/spyder-ide/spyder-unittest.svg?branch=master)](https://travis-ci.org/spyder-ide/spyder-unittest)
 [![Build status](https://ci.appveyor.com/api/projects/status/d9wa6whp1fpq4uii?svg=true)](https://ci.appveyor.com/project/spyder-ide/spyder-unittest)
 [![CircleCI](https://circleci.com/gh/spyder-ide/spyder-unittest/tree/master.svg?style=shield)](https://circleci.com/gh/spyder-ide/spyder-unittest/tree/master)
 [![Coverage Status](https://coveralls.io/repos/github/spyder-ide/spyder-unittest/badge.svg?branch=master)](https://coveralls.io/github/spyder-ide/spyder-unittest?branch=master)
 
+![Screenshot of spyder-unittest plugin](./screenshot.png)
+
 ----
 
-## Important Announcement: Spyder is unfunded!
+## Important Announcement: Spyder needs your support!
 
-Since mid November/2017, [Anaconda, Inc](https://www.anaconda.com/) has
-stopped funding Spyder development, after doing it for the past 18
-months. Because of that, development will focus from now on maintaining
-Spyder 3 at a much slower pace than before.
+Since mid-November 2017, [Anaconda, Inc](https://www.anaconda.com/) has
+stopped funding Spyder development, after doing so for the past 18
+months. Therefore, without additional funds, development will shift to
+maintaining Spyder 3 at a slower pace than before, while working
+toward an eventual Spyder 4 feature release sometime in the future.
+At the moment we do not plan to spend much effort on the development of 
+Spyder plugins, such as this one.
 
-If you want to contribute to maintain Spyder, please consider donating at
+However, with your contribution of effort and funding, we will be able to
+both continue to maintain Spyder 3 at a faster pace, and fund development of
+new features for Spyder 4 and its plugins (including this plugin and the
+spyder-notebook plugin) at a greatly accelerated rate.
 
-https://opencollective.com/spyder
+There are many ways to [help with development](
+https://github.com/spyder-ide/spyder/wiki/Contributing-to-Spyder), many of
+which don't require any programming, and if you're able to make a
+financial contribution to help support your favorite community IDE, you can
+donate through our [OpenCollective](https://opencollective.com/spyder).
 
 We appreciate all the help you can provide us and can't thank you enough for
-supporting the work of Spyder devs and Spyder development.
-
-If you want to know more about this, please read this
-[page](https://github.com/spyder-ide/spyder/wiki/Anaconda-stopped-funding-Spyder).
+supporting the work of the Spyder devs and Spyder development! To learn more
+about the current situation and our future plans, please read this [page](
+https://github.com/spyder-ide/spyder/wiki/Anaconda-stopped-funding-Spyder).
 
 ----
 
 ## Description
 
-![screenshot](./screenshot.png)
-
-This is a plugin for Spyder that integrates popular unit test
+Spyder-unittest is a plugin for Spyder that integrates popular unit test
 frameworks. It allows you to run tests and view the results.
 
 The plugin supports the `unittest` framework in the Python

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # spyder-unittest
 
+Copyright © 2014–2018 Spyder Project Contributors
+
 [![license](https://img.shields.io/pypi/l/spyder-unittest.svg)](./LICENSE)
 [![pypi version](https://img.shields.io/pypi/v/spyder-unittest.svg)](https://pypi.python.org/pypi/spyder-unittest)
 [![Join the chat at https://gitter.im/spyder-ide/public](https://badges.gitter.im/spyder-ide/spyder.svg)](https://gitter.im/spyder-ide/public)

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Copyright © 2014–2018 Spyder Project Contributors
 
 [![license](https://img.shields.io/pypi/l/spyder-unittest.svg)](./LICENSE)
 [![pypi version](https://img.shields.io/pypi/v/spyder-unittest.svg)](https://pypi.python.org/pypi/spyder-unittest)
+[![conda version](https://img.shields.io/conda/v/spyder-ide/spyder-unittest.svg)](https://www.anaconda.com/download/)
+[![download count](https://img.shields.io/conda/d/spyder-ide/spyder-unittest.svg)](https://www.anaconda.com/download/)
 [![Join the chat at https://gitter.im/spyder-ide/public](https://badges.gitter.im/spyder-ide/spyder.svg)](https://gitter.im/spyder-ide/public)
-[![OpenCollective Backers](https://opencollective.com/spyder/backers/badge.svg?color=blue)](#backers)
-[![OpenCollective Sponsors](https://opencollective.com/spyder/sponsors/badge.svg?color=blue)](#sponsors)
 
 [![Build Status](https://travis-ci.org/spyder-ide/spyder-unittest.svg?branch=master)](https://travis-ci.org/spyder-ide/spyder-unittest)
 [![Build status](https://ci.appveyor.com/api/projects/status/d9wa6whp1fpq4uii?svg=true)](https://ci.appveyor.com/project/spyder-ide/spyder-unittest)
@@ -24,7 +24,7 @@ stopped funding Spyder development, after doing so for the past 18
 months. Therefore, without additional funds, development will shift to
 maintaining Spyder 3 at a slower pace than before, while working
 toward an eventual Spyder 4 feature release sometime in the future.
-At the moment we do not plan to spend much effort on the development of 
+At the moment we do not plan to spend much effort on the development of
 Spyder plugins, such as this one.
 
 However, with your contribution of effort and funding, we will be able to
@@ -68,14 +68,14 @@ you can use the plugin.
 ## Usage
 
 The plugin adds an item `Run unit tests` to the `Run` menu in Spyder.
-Click on this to run the unit tests. After you specify the testing framework 
-and the directory under which the tests are stored, the tests are run. 
-The `Unit testing` window pane (displayed at the top of this file) will pop up 
+Click on this to run the unit tests. After you specify the testing framework
+and the directory under which the tests are stored, the tests are run.
+The `Unit testing` window pane (displayed at the top of this file) will pop up
 with the results. If you are using `py.test`, you can double-click on a test
 to view it in the editor.
 
 If you want to run tests in a different directory or switch testing
-frameworks, click `Configure` in the Options menu (cogwheel icon), 
+frameworks, click `Configure` in the Options menu (cogwheel icon),
 which is located in the upper right corner of the `Unit testing` pane.
 
 ## Feedback
@@ -98,8 +98,8 @@ The plugin has the following dependencies:
   and/or [nose](https://nose.readthedocs.io)
 
 In order to run the tests distributed with this plugin, you need
-[nose](https://nose.readthedocs.io), [py.test](https://pytest.org) 
-and [pytest-qt](https://github.com/pytest-dev/pytest-qt). If you use Python 2, 
+[nose](https://nose.readthedocs.io), [py.test](https://pytest.org)
+and [pytest-qt](https://github.com/pytest-dev/pytest-qt). If you use Python 2,
 you also need [mock](https://github.com/testing-cabal/mock).
 
 You are very welcome to submit code contributations in the form of pull
@@ -113,16 +113,9 @@ locally and run them before submitting the code.
 
 ## Contributing
 
-Everyone is welcome to contribute!
+Everyone is welcome to contribute! The document [Contributing to Spyder](
+https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
+also applies to the unittest plugin.
 
-## Backers
-
-Support us with a monthly donation and help us continue our activities.
-
-[![Backers](https://opencollective.com/spyder/backers.svg)](https://opencollective.com/spyder#support)
-
-## Sponsors
-
-Become a sponsor to get your logo on our README on Github.
-
-[![Sponsors](https://opencollective.com/spyder/sponsors.svg)](https://opencollective.com/spyder#support)
+We are grateful to the entire Spyder community for their support, without which
+this plugin and the whole of Spyder would be a lot less awesome.

--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,8 @@ LONG_DESCRIPTION = """
 This is a plugin for the Spyder IDE that integrates popular unit test
 frameworks. It allows you to run tests and view the results.
 
-**Status:**
-This is a work in progress. It is useable, but only the basic functionality
-is implemented at the moment. The plugin currently supports the py.test and nose
-testing frameworks.
+The plugin supports the `unittest` framework in the Python
+standard library and the `py.test` and `nose` testing frameworks.
 """
 
 setup(


### PR DESCRIPTION
Update long description used on the Pypi website. Update README by adopting a more positive tone in funding announcement, moving it below the screen shot, and removing the headings with the badges (shamelessly lifted from spyder-ide/spyder#6923).