### PR TITLE
Replace 'py.test' by 'pytest'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,4 +52,4 @@ install:
 
 script:
   - ciocheck spyder_unittest --disable-tests
-  - py.test spyder_unittest --cov=spyder_unittest
+  - pytest spyder_unittest --cov=spyder_unittest

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Spyder-unittest is a plugin for Spyder that integrates popular unit test
 frameworks. It allows you to run tests and view the results.
 
 The plugin supports the `unittest` framework in the Python
-standard library and the `py.test` and `nose` testing frameworks.
-Support for `py.test` is most complete at the moment.
+standard library and the `pytest` and `nose` testing frameworks.
+Support for `pytest` is most complete at the moment.
 
 ## Installation
 
@@ -71,7 +71,7 @@ The plugin adds an item `Run unit tests` to the `Run` menu in Spyder.
 Click on this to run the unit tests. After you specify the testing framework
 and the directory under which the tests are stored, the tests are run.
 The `Unit testing` window pane (displayed at the top of this file) will pop up
-with the results. If you are using `py.test`, you can double-click on a test
+with the results. If you are using `pytest`, you can double-click on a test
 to view it in the editor.
 
 If you want to run tests in a different directory or switch testing
@@ -94,11 +94,11 @@ The plugin has the following dependencies:
 
 * [spyder](https://github.com/spyder-ide/spyder) (obviously), at least version 3.0
 * [lxml](http://lxml.de/)
-* the testing framework that you will be using: [py.test](https://pytest.org)
+* the testing framework that you will be using: [pytest](https://pytest.org)
   and/or [nose](https://nose.readthedocs.io)
 
 In order to run the tests distributed with this plugin, you need
-[nose](https://nose.readthedocs.io), [py.test](https://pytest.org)
+[nose](https://nose.readthedocs.io), [pytest](https://pytest.org)
 and [pytest-qt](https://github.com/pytest-dev/pytest-qt). If you use Python 2,
 you also need [mock](https://github.com/testing-cabal/mock).
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,4 +64,4 @@ build: false
 test_script:
   - ciocheck spyder_unittest --disable-tests
   - conda remove pytest-xdist
-  - py.test spyder_unittest --cov=spyder_unittest
+  - pytest spyder_unittest --cov=spyder_unittest

--- a/circle.yml
+++ b/circle.yml
@@ -41,10 +41,10 @@ dependencies:
 test:
   override:
     # Check PyQt5
-    - export PATH="$HOME/miniconda/bin:$PATH" && source activate test && export PYTEST_QT_API="pyqt5" && conda install -q qt=5.* pyqt=5.* && py.test spyder_unittest --cov=spyder_unittest: # note the colon
+    - export PATH="$HOME/miniconda/bin:$PATH" && source activate test && export PYTEST_QT_API="pyqt5" && conda install -q qt=5.* pyqt=5.* && pytest spyder_unittest --cov=spyder_unittest: # note the colon
         parallel: true
     # Check PyQt4 (but not on Python 3.6)
-    - if [ "$CIRCLE_NODE_INDEX" != "0" ]; then export PATH="$HOME/miniconda/bin:$PATH" && source activate test && export PYTEST_QT_API="pyqt4v2" && conda install -q qt=4.* pyqt=4.* && py.test spyder_unittest --cov=spyder_unittest; fi: # note the colon
+    - if [ "$CIRCLE_NODE_INDEX" != "0" ]; then export PATH="$HOME/miniconda/bin:$PATH" && source activate test && export PYTEST_QT_API="pyqt4v2" && conda install -q qt=4.* pyqt=4.* && pytest spyder_unittest --cov=spyder_unittest; fi: # note the colon
         parallel: true
   post:
     - export PATH="$HOME/miniconda/bin:$PATH" && source activate test && coveralls

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ This is a plugin for the Spyder IDE that integrates popular unit test
 frameworks. It allows you to run tests and view the results.
 
 The plugin supports the `unittest` framework in the Python
-standard library and the `py.test` and `nose` testing frameworks.
+standard library and the `pytest` and `nose` testing frameworks.
 """
 
 setup(

--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -3,7 +3,7 @@
 # Copyright © 2013 Spyder Project Contributors
 # Licensed under the terms of the MIT License
 # (see LICENSE.txt for details)
-"""Support for py.test framework."""
+"""Support for pytest framework."""
 
 # Standard library imports
 import os
@@ -15,10 +15,10 @@ from spyder_unittest.backend.zmqstream import ZmqStreamReader
 
 
 class PyTestRunner(RunnerBase):
-    """Class for running tests within py.test framework."""
+    """Class for running tests within pytest framework."""
 
     module = 'pytest'
-    name = 'py.test'
+    name = 'pytest'
 
     def create_argument_list(self):
         """Create argument list for testing process."""

--- a/spyder_unittest/backend/pytestworker.py
+++ b/spyder_unittest/backend/pytestworker.py
@@ -4,10 +4,10 @@
 # Licensed under the terms of the MIT License
 # (see LICENSE.txt for details)
 """
-Script for running py.test tests.
+Script for running pytest tests.
 
 This script is meant to be run in a separate process by a PyTestRunner.
-It runs tests via the py.test framework and prints the results so that the
+It runs tests via the pytest framework and prints the results so that the
 PyTestRunner can read them.
 """
 
@@ -45,7 +45,7 @@ class SpyderPlugin():
         self.writer = writer
 
     def pytest_collectreport(self, report):
-        """Called by py.test after collecting tests from a file."""
+        """Called by pytest after collecting tests from a file."""
         if report.outcome == 'failed':
             self.writer.write({
                     'event': 'collecterror',
@@ -54,7 +54,7 @@ class SpyderPlugin():
             })
 
     def pytest_itemcollected(self, item):
-        """Called by py.test when a test item is collected."""
+        """Called by pytest when a test item is collected."""
         nodeid = item.name
         x = item.parent
         while x.parent:
@@ -66,14 +66,14 @@ class SpyderPlugin():
         })
 
     def pytest_runtest_logstart(self, nodeid, location):
-        """Called by py.test before running a test."""
+        """Called by pytest before running a test."""
         self.writer.write({
             'event': 'starttest',
             'nodeid': nodeid
         })
 
     def pytest_runtest_logreport(self, report):
-        """Called by py.test when a (phase of a) test is completed."""
+        """Called by pytest when a (phase of a) test is completed."""
         if report.when in ['setup', 'teardown'] and report.outcome == 'passed':
             return
         data = {'event': 'logreport',
@@ -97,7 +97,7 @@ class SpyderPlugin():
 
 
 def main(args):
-    """Run py.test with the Spyder plugin."""
+    """Run pytest with the Spyder plugin."""
     if args[1] == 'file':
         writer = FileStub('pytestworker.log')
     else:

--- a/spyder_unittest/backend/tests/test_pytestrunner.py
+++ b/spyder_unittest/backend/tests/test_pytestrunner.py
@@ -53,7 +53,7 @@ def test_pytestrunner_start(monkeypatch):
     mock_reader.port = 42
 
     runner = PyTestRunner(None, 'results')
-    config = Config('py.test', 'wdir')
+    config = Config('pytest', 'wdir')
     runner.start(config, ['pythondir'])
 
     mock_process.setWorkingDirectory.assert_called_once_with('wdir')

--- a/spyder_unittest/tests/test_unittestplugin.py
+++ b/spyder_unittest/tests/test_unittestplugin.py
@@ -105,10 +105,10 @@ def test_plugin_config(plugin, tmpdir, qtbot):
     assert plugin.unittestwidget.config is None
 
     # Set config and test that this is recorded in config file
-    config = Config(framework='ham', wdir=str(tmpdir))
+    config = Config(framework='unittest', wdir=str(tmpdir))
     with qtbot.waitSignal(plugin.unittestwidget.sig_newconfig):
         plugin.unittestwidget.config = config
-    assert 'framework = ham' in config_file_path.read().splitlines()
+    assert 'framework = unittest' in config_file_path.read().splitlines()
 
     # Close project and test that config is empty
     plugin.main.projects.get_active_project = lambda: None

--- a/spyder_unittest/widgets/configdialog.py
+++ b/spyder_unittest/widgets/configdialog.py
@@ -157,6 +157,6 @@ def ask_for_config(frameworks, config, parent=None):
 
 if __name__ == '__main__':
     app = QApplication([])
-    frameworks = ['nose', 'py.test', 'unittest']
+    frameworks = ['nose', 'pytest', 'unittest']
     config = Config(framework=None, wdir=getcwd())
     print(ask_for_config(frameworks, config))

--- a/spyder_unittest/widgets/tests/test_unittestgui.py
+++ b/spyder_unittest/widgets/tests/test_unittestgui.py
@@ -47,6 +47,14 @@ def test_unittestwidget_set_config_does_not_emit_when_invalid(qtbot):
         widget.config = config
     assert widget.config == config
 
+def test_unittestwidget_config_with_unknown_framework_invalid(qtbot):
+    """Check that if the framework in the config is not known,
+    config_is_valid() returns False"""
+    widget = UnitTestWidget(None)
+    qtbot.addWidget(widget)
+    config = Config(wdir=os.getcwd(), framework='unknown framework')
+    assert widget.config_is_valid(config) == False
+
 def test_unittestwidget_process_finished_updates_results(qtbot):
     widget = UnitTestWidget(None)
     widget.testdatamodel = Mock()

--- a/spyder_unittest/widgets/tests/test_unittestgui.py
+++ b/spyder_unittest/widgets/tests/test_unittestgui.py
@@ -150,7 +150,7 @@ def test_run_tests_with_pre_test_hook_returning_false(qtbot):
     widget.pre_test_hook.call_count == 1
     mockRunner.start.call_count == 0
 
-@pytest.mark.parametrize('framework', ['py.test', 'nose'])
+@pytest.mark.parametrize('framework', ['pytest', 'nose'])
 def test_run_tests_and_display_results(qtbot, tmpdir, monkeypatch, framework):
     """Basic integration test."""
     os.chdir(tmpdir.strpath)

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -204,7 +204,9 @@ class UnitTestWidget(QWidget):
         """
         if config is None:
             config = self.config
-        return (config and config.framework and osp.isdir(config.wdir))
+        return (config and config.framework
+                and config.framework in self.framework_registry.frameworks
+                and osp.isdir(config.wdir))
 
     def maybe_configure_and_start(self):
         """

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -377,7 +377,7 @@ def test():
 
     # set wdir to .../spyder_unittest
     wdir = osp.abspath(osp.join(osp.dirname(__file__), osp.pardir))
-    widget.config = Config('py.test', wdir)
+    widget.config = Config('pytest', wdir)
 
     # add wdir's parent to python path, so that `import spyder_unittest` works
     rootdir = osp.abspath(osp.join(wdir, osp.pardir))


### PR DESCRIPTION
The pytest testing framework uses the spelling "pytest" instead of "py.test" since at least version 3.0 released in August 2016. This PR propagates the change to the spyder plugin.

As a result, all existing testing configurations are rendered invalid. I decided to handle this by forcing users to select the framework again. I could have special-cased this when reading the config, but I think it's only a minor inconvenience for our users and the plugin is still in 0.x version.