### PR TITLE
Remove unused variables when initializing localization

### DIFF
--- a/spyder_unittest/backend/noserunner.py
+++ b/spyder_unittest/backend/noserunner.py
@@ -14,7 +14,7 @@ from spyder_unittest.backend.runnerbase import Category, RunnerBase, TestResult
 
 try:
     _ = get_translation("unittest", dirname="spyder_unittest")
-except KeyError as error:
+except KeyError:
     import gettext
     _ = gettext.gettext
 

--- a/spyder_unittest/widgets/configdialog.py
+++ b/spyder_unittest/widgets/configdialog.py
@@ -25,7 +25,7 @@ from spyder.utils import icon_manager as ima
 
 try:
     _ = get_translation("unittest", dirname="spyder_unittest")
-except KeyError as error:
+except KeyError:
     import gettext
     _ = gettext.gettext
 

--- a/spyder_unittest/widgets/datatree.py
+++ b/spyder_unittest/widgets/datatree.py
@@ -23,7 +23,7 @@ from spyder_unittest.backend.runnerbase import Category
 
 try:
     _ = get_translation("unittest", dirname="spyder_unittest")
-except KeyError as error:
+except KeyError:
     import gettext
     _ = gettext.gettext
 

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -33,7 +33,7 @@ from spyder_unittest.widgets.datatree import TestDataModel, TestDataView
 # This is needed for testing this module as a stand alone script
 try:
     _ = get_translation("unittest", dirname="spyder_unittest")
-except KeyError as error:
+except KeyError:
     import gettext
     _ = gettext.gettext
 


### PR DESCRIPTION
This fixes a code style warning which suddenly popped up on one of the CI servers.