### PR TITLE
PR: Use nodeid provided by pytest in itemcollected hook

### DIFF
--- a/spyder_unittest/backend/pytestworker.py
+++ b/spyder_unittest/backend/pytestworker.py
@@ -55,14 +55,9 @@ class SpyderPlugin():
 
     def pytest_itemcollected(self, item):
         """Called by pytest when a test item is collected."""
-        nodeid = item.name
-        x = item.parent
-        while x.parent:
-            nodeid = x.name + '::' + nodeid
-            x = x.parent
         self.writer.write({
             'event': 'collected',
-            'nodeid': nodeid
+            'nodeid': item.nodeid
         })
 
     def pytest_runtest_logstart(self, nodeid, location):

--- a/spyder_unittest/backend/tests/test_pytestworker.py
+++ b/spyder_unittest/backend/tests/test_pytestworker.py
@@ -52,12 +52,7 @@ def test_spyderplugin_test_collectreport_with_failure(plugin):
 
 def test_spyderplugin_test_itemcollected(plugin):
     testitem = EmptyClass()
-    testitem.name = 'bar'
-    testitem.parent = EmptyClass()
-    testitem.parent.name = 'foo.py'
-    testitem.parent.parent = EmptyClass
-    testitem.parent.parent.name = 'notused'
-    testitem.parent.parent.parent = None
+    testitem.nodeid = 'foo.py::bar'
     plugin.pytest_itemcollected(testitem)
     plugin.writer.write.assert_called_once_with({
         'event': 'collected',


### PR DESCRIPTION
This is simpler and more robust. In fact, I have no idea why I did not do this originally.

Fixes #128 