### PR TITLE
Fix TextEditor constructor

### DIFF
--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -181,11 +181,12 @@ class UnitTestWidget(QWidget):
     def show_log(self):
         """Show output of testing process."""
         if self.output:
-            TextEditor(
+            te = TextEditor(
                 self.output,
                 title=_("Unit testing output"),
-                readonly=True,
-                size=(700, 500)).exec_()
+                readonly=True)
+            te.resize(700,500)
+            te.exec_()
 
     def configure(self):
         """Configure tests."""

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -185,7 +185,7 @@ class UnitTestWidget(QWidget):
                 self.output,
                 title=_("Unit testing output"),
                 readonly=True)
-            te.resize(700,500)
+            te.resize(700, 500)
             te.exec_()
 
     def configure(self):


### PR DESCRIPTION
spyder-ide/spyder@e4c5b1a678b1e90be7191fa5c6f77acfb7aba8ca introduced dynamic window sizing and hence removed the size argument in the TextEditor constructor, which results in an error here. This commit restores the previous behavior.

The dynamic sizing doesn't work for me: if I don't explicitly resize the window I end up with a window size of 278 x 242 pixel on my 1900 x 1200 double screen setup (Windows 10). If I just specify `te.show()` instead of `te.resize(700, 500)` then I get the same 700 x 500 window size. Maybe someone more knowledgeable about QT can get the dynamic sizing to work, but for the time being this PR just restores the old behavior.