### PR TITLE
Fix status_label if no results to show

### DIFF
--- a/spyder_unittest/widgets/tests/test_unittestgui.py
+++ b/spyder_unittest/widgets/tests/test_unittestgui.py
@@ -215,3 +215,23 @@ def test_run_tests_using_unittest_and_display_results(qtbot, tmpdir,
     assert model.index(1, 1).data(Qt.DisplayRole) == 't.M.test_ok'
     assert model.index(1, 1).data(Qt.ToolTipRole) == 'test_foo.MyTest.test_ok'
     assert model.index(1, 2).data(Qt.DisplayRole) == ''
+    assert widget.status_label.text() == '<b>1 test failed, 1 passed</b>'
+
+def test_run_no_tests_using_unittest_and_display_results(qtbot, tmpdir,
+                                                         monkeypatch):
+    """Basic check."""
+    os.chdir(tmpdir.strpath)
+
+    MockQMessageBox = Mock()
+    monkeypatch.setattr('spyder_unittest.widgets.unittestgui.QMessageBox',
+                        MockQMessageBox)
+
+    widget = UnitTestWidget(None)
+    qtbot.addWidget(widget)
+    config = Config(wdir=tmpdir.strpath, framework='unittest')
+    with qtbot.waitSignal(widget.sig_finished, timeout=10000, raising=True):
+        widget.run_tests(config)
+
+    MockQMessageBox.assert_not_called()
+    assert widget.testdatamodel.rowCount() == 0
+    assert widget.status_label.text() == '<b>No results to show.</b>'

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -316,7 +316,7 @@ class UnitTestWidget(QWidget):
         self.set_running_state(False)
         self.testrunner = None
         self.log_action.setEnabled(bool(output))
-        if testresults:
+        if testresults is not None:
             self.testdatamodel.testresults = testresults
         self.replace_pending_with_not_run()
         self.sig_finished.emit()


### PR DESCRIPTION
status_label update is triggered by assignment of test results in
process_finished. In case of no results, process_finished is called
with an empty list of testresults. This empty list must also be
assigned in order to trigger the status_label update, otherwise the
status remains "Running tests ..." after finishing. So we have to
differentiate between None and [] in the if clause.

Without the fix it looks like this after running when no tests were discovered:
![grafik](https://user-images.githubusercontent.com/19879328/78247863-e963f480-74eb-11ea-9399-e7d70ec511b2.png)
