### PR TITLE
Fix status label

### DIFF
--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -78,7 +78,7 @@ class PyTestRunner(RunnerBase):
         """
         self.reader.close()
         output = self.read_all_process_output()
-        self.sig_finished.emit(None, output)
+        self.sig_finished.emit([] if "no tests ran" in output else None, output)
 
 
 def normalize_module_name(name):

--- a/spyder_unittest/backend/runnerbase.py
+++ b/spyder_unittest/backend/runnerbase.py
@@ -102,6 +102,8 @@ class RunnerBase(QObject):
     sig_finished(list of TestResult, str)
         Emitted when test process finishes. First argument contains the test
         results, second argument contains the output of the test process.
+    sig_stop()
+        Emitted when test process is being stopped.
     """
 
     sig_collected = Signal(object)
@@ -109,6 +111,7 @@ class RunnerBase(QObject):
     sig_starttest = Signal(object)
     sig_testresult = Signal(object)
     sig_finished = Signal(object, str)
+    sig_stop = Signal()
 
     def __init__(self, widget, resultfilename=None):
         """
@@ -228,3 +231,4 @@ class RunnerBase(QObject):
         """Stop testing process if it is running."""
         if self.process and self.process.state() == QProcess.Running:
             self.process.kill()
+            self.sig_stop.emit()

--- a/spyder_unittest/backend/unittestrunner.py
+++ b/spyder_unittest/backend/unittestrunner.py
@@ -47,35 +47,38 @@ class UnittestRunner(RunnerBase):
         lines = output.splitlines()
         line_index = 0
 
-        while lines[line_index]:
-            data = self.try_parse_result(lines, line_index)
-            if data:
-                line_index = data[0]
-                if data[3] == 'ok':
-                    cat = Category.OK
-                elif data[3] == 'FAIL' or data[3] == 'ERROR':
-                    cat = Category.FAIL
+        try:
+            while lines[line_index]:
+                data = self.try_parse_result(lines, line_index)
+                if data:
+                    line_index = data[0]
+                    if data[3] == 'ok':
+                        cat = Category.OK
+                    elif data[3] == 'FAIL' or data[3] == 'ERROR':
+                        cat = Category.FAIL
+                    else:
+                        cat = Category.SKIP
+                    name = '{}.{}'.format(data[2], data[1])
+                    tr = TestResult(category=cat, status=data[3], name=name,
+                                    message=data[4])
+                    res.append(tr)
                 else:
-                    cat = Category.SKIP
-                name = '{}.{}'.format(data[2], data[1])
-                tr = TestResult(category=cat, status=data[3], name=name,
-                                message=data[4])
-                res.append(tr)
-            else:
-                line_index += 1
+                    line_index += 1
 
-        line_index += 1
-        while not (lines[line_index]
-                   and all(c == '-' for c in lines[line_index])):
-            data = self.try_parse_exception_block(lines, line_index)
-            if data:
-                line_index = data[0]
-                test_index = next(
-                    i for i, tr in enumerate(res)
-                    if tr.name == '{}.{}'.format(data[2], data[1]))
-                res[test_index].extra_text = data[3]
-            else:
-                line_index += 1
+            line_index += 1
+            while not (lines[line_index]
+                       and all(c == '-' for c in lines[line_index])):
+                data = self.try_parse_exception_block(lines, line_index)
+                if data:
+                    line_index = data[0]
+                    test_index = next(
+                        i for i, tr in enumerate(res)
+                        if tr.name == '{}.{}'.format(data[2], data[1]))
+                    res[test_index].extra_text = data[3]
+                else:
+                    line_index += 1
+        except IndexError:
+            pass
 
         return res
 

--- a/spyder_unittest/widgets/tests/test_unittestgui.py
+++ b/spyder_unittest/widgets/tests/test_unittestgui.py
@@ -150,6 +150,14 @@ def test_run_tests_with_pre_test_hook_returning_false(qtbot):
     widget.pre_test_hook.call_count == 1
     mockRunner.start.call_count == 0
 
+@pytest.mark.parametrize('results,label',
+                         [([TestResult(Category.OK, 'ok', '')], '0 tests failed, 1 passed'),
+                          ([], 'No results to show.')])
+def test_unittestwidget_process_finished_updates_status_label(qtbot, results, label):
+    widget = UnitTestWidget(None)
+    widget.process_finished(results, 'output')
+    assert widget.status_label.text() == '<b>{}</b>'.format(label)
+
 @pytest.mark.parametrize('framework', ['pytest', 'nose'])
 def test_run_tests_and_display_results(qtbot, tmpdir, monkeypatch, framework):
     """Basic integration test."""

--- a/spyder_unittest/widgets/tests/test_unittestgui.py
+++ b/spyder_unittest/widgets/tests/test_unittestgui.py
@@ -229,7 +229,6 @@ def test_run_with_no_tests_discovered_and_display_results(qtbot, tmpdir,
                                                           monkeypatch, framework):
     """Basic integration test."""
     os.chdir(tmpdir.strpath)
-    testfilename = tmpdir.join('test_foo.py').strpath
 
     MockQMessageBox = Mock()
     monkeypatch.setattr('spyder_unittest.widgets.unittestgui.QMessageBox',

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -316,7 +316,7 @@ class UnitTestWidget(QWidget):
         self.set_running_state(False)
         self.testrunner = None
         self.log_action.setEnabled(bool(output))
-        if testresults:
+        if testresults is not None:
             self.testdatamodel.testresults = testresults
         self.replace_pending_with_not_run()
         self.sig_finished.emit()

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -260,6 +260,7 @@ class UnitTestWidget(QWidget):
         self.testrunner.sig_collecterror.connect(self.tests_collect_error)
         self.testrunner.sig_starttest.connect(self.tests_started)
         self.testrunner.sig_testresult.connect(self.tests_yield_result)
+        self.testrunner.sig_stop.connect(self.tests_stopped)
 
         try:
             self.testrunner.start(config, pythonpath)
@@ -357,6 +358,10 @@ class UnitTestWidget(QWidget):
     def tests_yield_result(self, testresults):
         """Called when test results are received."""
         self.testdatamodel.update_testresults(testresults)
+
+    def tests_stopped(self):
+        """Called when tests are stopped"""
+        self.status_label.setText('')
 
     def set_status_label(self, msg):
         """


### PR DESCRIPTION
- Fix status_label if no results to show
   status_label update is triggered by assignment of test results in
    process_finished. In case of no results, process_finished is called
    with an empty list of testresults. This empty list must also be
    assigned in order to trigger the status_label update, otherwise the
    status remains "Running tests ..." after finishing. So we have to
    differentiate between None and [] in the if clause.

    Without the fix it looks like this after running when no tests were discovered:
    ![grafik](https://user-images.githubusercontent.com/19879328/78247863-e963f480-74eb-11ea-9399-e7d70ec511b2.png)

- Reset status_label when running tests is stopped
    and make parsing errors in unittestrunner.load_data indeed ignored silently
    (it relies on the condition that the result includes the final line of all
    dashes, otherwise an Indexerror will occur)

    Without the fix the status label "Running tests ..." remains visible after stopping
    the run.
