### PR TITLE
Dynamic sizing of text editor window

### DIFF
--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -185,7 +185,7 @@ class UnitTestWidget(QWidget):
                 self.output,
                 title=_("Unit testing output"),
                 readonly=True)
-            te.resize(700, 500)
+            te.show()
             te.exec_()
 
     def configure(self):


### PR DESCRIPTION
using `BaseDialog`'s `set_dynamic_width_and_height`.

This is further to #139 and resolves spyder-ide/spyder#12202.