### PR TITLE
Fix abbreviator if name has parameters with dots

### DIFF
--- a/spyder_unittest/backend/abbreviator.py
+++ b/spyder_unittest/backend/abbreviator.py
@@ -44,6 +44,7 @@ class Abbreviator:
         ---------
         name : str
         """
+        name = name.split('[', 1)[0]
         if '.' not in name:
             return
         len_abbrev = 1
@@ -70,10 +71,15 @@ class Abbreviator:
 
     def abbreviate(self, name):
         """Return abbreviation of name."""
+        if '[' in name:
+            name, parameters = name.split('[', 1)
+            parameters = '[' + parameters
+        else:
+            parameters = ''
         if '.' in name:
             start, rest = name.split('.', 1)
             res = (self.dic[start][0]
                    + '.' + self.dic[start][1].abbreviate(rest))
         else:
             res = name
-        return res
+        return res + parameters

--- a/spyder_unittest/backend/abbreviator.py
+++ b/spyder_unittest/backend/abbreviator.py
@@ -12,10 +12,10 @@ class Abbreviator:
 
     First, if the name contains brackets, the part in brackets starting at
     the first bracket is removed from the name. Then, all names are split
-    in components separated by full stop (like module names in Python).
+    in components separated by full stops (like module names in Python).
     Every component is abbreviated by the smallest prefix not shared by
     other names in the same directory, except for the last component which
-    is not changed. Finally, the part in bracket, which was removed at the
+    is not changed. Finally, the part in brackets, which was removed at the
     beginning, is appended to the abbreviated name.
 
     Attributes

--- a/spyder_unittest/backend/abbreviator.py
+++ b/spyder_unittest/backend/abbreviator.py
@@ -10,10 +10,13 @@ class Abbreviator:
     """
     Abbreviates names so that abbreviation identifies name uniquely.
 
-    First, all names are split in components separated by full stop (like
-    module names in Python). Every component is abbreviated by the smallest
-    prefix not shared by other names in the same directory, except for the
-    last component which is not changed.
+    First, if the name contains brackets, the part in brackets starting at
+    the first bracket is removed from the name. Then, all names are split
+    in components separated by full stop (like module names in Python).
+    Every component is abbreviated by the smallest prefix not shared by
+    other names in the same directory, except for the last component which
+    is not changed. Finally, the part in bracket, which was removed at the
+    beginning, is appended to the abbreviated name.
 
     Attributes
     ----------

--- a/spyder_unittest/backend/tests/test_abbreviator.py
+++ b/spyder_unittest/backend/tests/test_abbreviator.py
@@ -57,3 +57,13 @@ def test_abbreviator_with_multilevel():
     assert abb.abbreviate('ham.spam.bar') == 'h.s.bar'
     assert abb.abbreviate('eggs.ham.foo') == 'e.ham.foo'
     assert abb.abbreviate('eggs.hamspam.bar') == 'e.hams.bar'
+
+def test_abbreviator_with_one_word_and_parameters_with_dot():
+    abb = Abbreviator()
+    abb.add('ham[.]')
+    assert abb.abbreviate('ham[x.]') == 'ham[x.]'
+
+def test_abbreviator_with_one_word_with_two_components_and_parameters_with_dot():
+    abb = Abbreviator()
+    abb.add('ham.spam[.]')
+    assert abb.abbreviate('ham.spam[x.]') == 'h.spam[x.]'


### PR DESCRIPTION
The name of a test is the dotted test function name possibly followed
by a list of parameters in brackets. These parameters can contain dots
as for example in [`test_unittestwidget_process_finished_updates_status_label`](https://github.com/spyder-ide/spyder-unittest/blob/57363140274af14151ae5826c77e47fdfa3df6ac/spyder_unittest/widgets/tests/test_unittestgui.py#L155)
from `test_unittestgui.py` where the label of the second parameter ends
with a dot, which led to the wrong abbreviation `'s.w.t.test_u.t.]'`. This
is fixed by not taking into account the parameter list when abbreviating.

Current:
![falsch](https://user-images.githubusercontent.com/19879328/79340168-356e5a80-7f2a-11ea-881c-c4d5f9517d80.jpg)
Fixed:
![richtig](https://user-images.githubusercontent.com/19879328/79340180-3acba500-7f2a-11ea-9fa0-849fd09b6474.jpg)
