### PR TITLE
Use set_status_label function

### DIFF
--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -287,7 +287,7 @@ class UnitTestWidget(QWidget):
                                  _("Error"), _("Process failed to start"))
         else:
             self.set_running_state(True)
-            self.status_label.setText(_('<b>Running tests ...<b>'))
+            self.set_status_label(_('Running tests ...'))
 
     def set_running_state(self, state):
         """


### PR DESCRIPTION
instead of setting the label directly. Thus the data (text) is decoupled from the formatting (bold tags).
This also ensure the correct closing tag (`</b>` instead of `<b>)` is used, although the incorrect one also worked fine.

Just an insignificant change but  I think it makes the translation strings more consistent.