### PR TITLE
Fix pytest test filename path resolution

### DIFF
--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -67,7 +67,9 @@ class PyTestRunner(RunnerBase):
         result_list = []
 
         for result_item in output:
-            if result_item['event'] == 'collected':
+            if result_item['event'] == 'config':
+                self.rootdir = result_item['rootdir']
+            elif result_item['event'] == 'collected':
                 testname = convert_nodeid_to_testname(result_item['nodeid'])
                 collected_list.append(testname)
             elif result_item['event'] == 'collecterror':
@@ -76,7 +78,7 @@ class PyTestRunner(RunnerBase):
             elif result_item['event'] == 'starttest':
                 starttest_list.append(logreport_starttest_to_str(result_item))
             elif result_item['event'] == 'logreport':
-                testresult = logreport_to_testresult(result_item, self.config)
+                testresult = logreport_to_testresult(result_item, self.rootdir)
                 result_list.append(testresult)
             elif result_item['event'] == 'finished':
                 self.output = result_item['stdout']
@@ -131,7 +133,7 @@ def logreport_starttest_to_str(report):
     return convert_nodeid_to_testname(report['nodeid'])
 
 
-def logreport_to_testresult(report, config):
+def logreport_to_testresult(report, rootdir):
     """Convert a logreport sent by test process to a TestResult."""
     status = report['outcome']
     if report['outcome'] in ('failed', 'xpassed') or report['witherror']:
@@ -148,7 +150,7 @@ def logreport_to_testresult(report, config):
             extra_text +=  '\n'
         for (heading, text) in report['sections']:
             extra_text += '----- {} -----\n{}'.format(heading, text)
-    filename = osp.join(config.wdir, report['filename'])
+    filename = osp.join(rootdir, report['filename'])
     result = TestResult(cat, status, testname, message=message,
                         time=report['duration'], extra_text=extra_text,
                         filename=filename, lineno=report['lineno'])

--- a/spyder_unittest/backend/pytestworker.py
+++ b/spyder_unittest/backend/pytestworker.py
@@ -61,6 +61,13 @@ class SpyderPlugin():
         self.was_skipped = False
         self.was_xfail = False
 
+    def pytest_report_header(self, config, startdir):
+        """Called by pytest before any reporting."""
+        self.writer.write({
+            'event': 'config',
+            'rootdir': str(config.rootdir)
+        })
+
     def pytest_collectreport(self, report):
         """Called by pytest after collecting tests from a file."""
         if report.outcome == 'failed':

--- a/spyder_unittest/backend/tests/test_pytestrunner.py
+++ b/spyder_unittest/backend/tests/test_pytestrunner.py
@@ -117,7 +117,7 @@ def standard_logreport_output():
 
 def test_pytestrunner_process_output_with_logreport_passed(qtbot):
     runner = PyTestRunner(None)
-    runner.config = Config(wdir='ham')
+    runner.rootdir = 'ham'
     output = [standard_logreport_output()]
     with qtbot.waitSignal(runner.sig_testresult) as blocker:
         runner.process_output(output)
@@ -148,7 +148,7 @@ def test_logreport_to_testresult_with_outcome_and_possible_error(outcome,
     report['witherror'] = witherror
     expected = TestResult(category, outcome, 'foo.bar', time=42,
                           filename=osp.join('ham', 'foo.py'), lineno=24)
-    assert logreport_to_testresult(report, Config(wdir='ham')) == expected
+    assert logreport_to_testresult(report, 'ham') == expected
 
 
 def test_logreport_to_testresult_with_message():
@@ -157,7 +157,7 @@ def test_logreport_to_testresult_with_message():
     expected = TestResult(Category.OK, 'passed', 'foo.bar', message='msg',
                           time=42, filename=osp.join('ham', 'foo.py'),
                           lineno=24)
-    assert logreport_to_testresult(report, Config(wdir='ham')) == expected
+    assert logreport_to_testresult(report, 'ham') == expected
 
 
 def test_logreport_to_testresult_with_extratext():
@@ -166,7 +166,7 @@ def test_logreport_to_testresult_with_extratext():
     expected = TestResult(Category.OK, 'passed', 'foo.bar', time=42,
                           extra_text='long msg',
                           filename=osp.join('ham', 'foo.py'), lineno=24)
-    assert logreport_to_testresult(report, Config(wdir='ham')) == expected
+    assert logreport_to_testresult(report, 'ham') == expected
 
 
 @pytest.mark.parametrize('longrepr,prefix', [
@@ -184,7 +184,7 @@ def test_logreport_to_testresult_with_output(longrepr, prefix):
     expected = TestResult(Category.OK, 'passed', 'foo.bar', time=42,
                           extra_text=txt, filename=osp.join('ham', 'foo.py'),
                           lineno=24)
-    assert logreport_to_testresult(report, Config(wdir='ham')) == expected
+    assert logreport_to_testresult(report, 'ham') == expected
 
 
 def test_get_versions_without_plugins(monkeypatch):


### PR DESCRIPTION
Pytest test filenames are relative to the `rootdir`. This `rootdir` is not
necessarily the directory from which discovery starts, i.e. `wdir` from
spyder-unittest's `config`. For details on how pytest determins the `rootdir` see
[Initialization: determining rootdir and inifile](https://docs.pytest.org/en/latest/customize.html#initialization-determining-rootdir-and-inifile.)
Filenames used to be resolved against `wdir`. If `wdir` is not the `rootdir` (as
described in the above link) this resulted in invalid resolved filenames.
This commit gets the `rootdir` in the `pytest_report_header` hook which is
called after all configuration is done and before any test collection
starts. This `rootdir` is then used for filename path resolution.

This resolves #145