### PR TITLE
Fix test_pytestrunner_start

### DIFF
--- a/spyder_unittest/backend/tests/test_pytestrunner.py
+++ b/spyder_unittest/backend/tests/test_pytestrunner.py
@@ -35,6 +35,13 @@ def test_pytestrunner_start(monkeypatch):
     mock_process = MockQProcess()
     mock_process.systemEnvironment = lambda: ['VAR=VALUE', 'PYTHONPATH=old']
 
+    def mock_add_pathlist_to_PYTHONPATH(env, _):
+        env[1] = 'PYTHONPATH=pythondir:old'
+
+    monkeypatch.setattr(
+        'spyder_unittest.backend.runnerbase.add_pathlist_to_PYTHONPATH',
+        mock_add_pathlist_to_PYTHONPATH)
+
     MockEnvironment = Mock()
     monkeypatch.setattr(
         'spyder_unittest.backend.runnerbase.QProcessEnvironment',
@@ -67,8 +74,7 @@ def test_pytestrunner_start(monkeypatch):
             get_python_executable(), [workerfile, '42'])
 
     mock_environment.insert.assert_any_call('VAR', 'VALUE')
-    # mock_environment.insert.assert_any_call('PYTHONPATH', 'pythondir:old')
-    # TODO: Find out why above test fails
+    mock_environment.insert.assert_any_call('PYTHONPATH', 'pythondir:old')
     mock_remove.called_once_with('results')
 
     assert runner.reader is mock_reader

--- a/spyder_unittest/backend/tests/test_runnerbase.py
+++ b/spyder_unittest/backend/tests/test_runnerbase.py
@@ -5,8 +5,20 @@
 # (see LICENSE.txt for details)
 """Tests for baserunner.py"""
 
+# Standard library imports
+import os
+
+# Third party imports
+import pytest
+
 # Local imports
 from spyder_unittest.backend.runnerbase import RunnerBase
+from spyder_unittest.widgets.configdialog import Config
+
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock  # Python 2
 
 
 def test_runnerbase_with_nonexisting_module():
@@ -14,3 +26,67 @@ def test_runnerbase_with_nonexisting_module():
         module = 'nonexisiting'
 
     assert not FooRunner.is_installed()
+
+
+@pytest.mark.parametrize('pythonpath,env_pythonpath', [
+    ([], None),
+    (['pythonpath'], None),
+    (['pythonpath'], 'old')
+])
+def test_runnerbase_prepare_process(monkeypatch, pythonpath, env_pythonpath):
+    MockQProcess = Mock()
+    monkeypatch.setattr('spyder_unittest.backend.runnerbase.QProcess',
+                        MockQProcess)
+    mock_process = MockQProcess()
+
+    MockEnvironment = Mock()
+    monkeypatch.setattr(
+        'spyder_unittest.backend.runnerbase.QProcessEnvironment.systemEnvironment',
+        MockEnvironment)
+    mock_environment = MockEnvironment()
+    mock_environment.configure_mock(**{'value.return_value': env_pythonpath})
+
+    config = Config('myRunner', 'wdir')
+    runner = RunnerBase(None, 'results')
+    runner._prepare_process(config, pythonpath)
+
+    mock_process.setWorkingDirectory.assert_called_once_with('wdir')
+    mock_process.finished.connect.assert_called_once_with(runner.finished)
+    if pythonpath:
+        if env_pythonpath:
+            mock_environment.insert.assert_any_call('PYTHONPATH',
+                                                    'pythonpath{}{}'.format(
+                                                        os.pathsep,
+                                                        env_pythonpath))
+        else:
+            mock_environment.insert.assert_any_call('PYTHONPATH', 'pythonpath')
+        mock_process.setProcessEnvironment.assert_called_once()
+    else:
+        mock_environment.insert.assert_not_called()
+        mock_process.setProcessEnvironment.assert_not_called()
+
+
+def test_runnerbase_start(monkeypatch):
+    MockQProcess = Mock()
+    monkeypatch.setattr('spyder_unittest.backend.runnerbase.QProcess',
+                        MockQProcess)
+    mock_process = MockQProcess()
+
+    mock_remove = Mock(side_effect=OSError())
+    monkeypatch.setattr('spyder_unittest.backend.runnerbase.os.remove',
+                        mock_remove)
+
+    monkeypatch.setattr(
+        'spyder_unittest.backend.runnerbase.get_python_executable',
+        lambda: 'python')
+
+    runner = RunnerBase(None, 'results')
+    runner._prepare_process = lambda c, p: mock_process
+    runner.create_argument_list = lambda: ['arg1', 'arg2']
+    config = Config('pytest', 'wdir')
+    mock_process.waitForStarted = lambda: False
+    with pytest.raises(RuntimeError):
+        runner.start(config, ['pythondir'])
+
+    mock_process.start.assert_called_once_with('python', ['arg1', 'arg2'])
+    mock_remove.assert_called_once_with('results')

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -409,7 +409,7 @@ def test():
 
     # add wdir's parent to python path, so that `import spyder_unittest` works
     rootdir = osp.abspath(osp.join(wdir, osp.pardir))
-    widget.pythonpath = rootdir
+    widget.pythonpath = [rootdir]
 
     widget.resize(800, 600)
     widget.show()


### PR DESCRIPTION
by patching `add_pathlist_to_PYTHONPATH`. This function first checks whether `PYTHONPATH` is set in the **actual** (!) OS environment and then changes the passed-in `env` list by either setting or prepending the `pathlist` to `PYTHONPATH`. The test failed if the OS environment in that the test is run hasn't set `PYTHONPATH`, as in the test, we call `add_pathlist_to_PYTHONPATH` with an `env` list where `PYTHONPATH` is already set.  

I'm not sure if this isn't a logic flaw in [`add_pathlist_to_PYTHONPATH`](https://github.com/spyder-ide/spyder/blob/e2db403d7a4a97690114f20da78e144ece3eeca6/spyder/utils/misc.py#L226): I think if `ipyconsole` is `False` it should look for `PYTHONPATH` not in the actual OS environment but in the passed-in `env` list. This doesn't play any role in the production code in the unittest plugin as we call `add_pathlist_to_PYTHONPATH` almost immediately after creating the new process, so its inherited environment will almost certainly correspond to the actual environment at the moment when `add_pathlist_to_PYTHONPATH` is being called . 
