### PR TITLE
Fix pytest backend

### DIFF
--- a/spyder_unittest/backend/pytestworker.py
+++ b/spyder_unittest/backend/pytestworker.py
@@ -44,6 +44,16 @@ class SpyderPlugin():
         """Constructor."""
         self.writer = writer
 
+    def initialize_logreport(self):
+        """Reset accumulator variables."""
+        self.status = '---'
+        self.duration = 0
+        self.longrepr = []
+        self.sections = []
+        self.had_error = False
+        self.was_skipped = False
+        self.was_xfail = False
+
     def pytest_collectreport(self, report):
         """Called by pytest after collecting tests from a file."""
         if report.outcome == 'failed':
@@ -66,30 +76,56 @@ class SpyderPlugin():
             'event': 'starttest',
             'nodeid': nodeid
         })
+        self.initialize_logreport()
 
     def pytest_runtest_logreport(self, report):
-        """Called by pytest when a (phase of a) test is completed."""
-        if report.when in ['setup', 'teardown'] and report.outcome == 'passed':
-            return
-        data = {'event': 'logreport',
-                'when': report.when,
-                'outcome': report.outcome,
-                'nodeid': report.nodeid,
-                'sections': report.sections,
-                'duration': report.duration,
-                'filename': report.location[0],
-                'lineno': report.location[1]}
-        if report.longrepr:
-            if isinstance(report.longrepr, tuple):
-                data['longrepr'] = report.longrepr
-            else:
-                data['longrepr'] = str(report.longrepr)
+        """Called by pytest when a phase of a test is completed."""
+        if report.when == 'call':
+            self.status = report.outcome
+            self.duration = report.duration
+        else:
+            if report.outcome == 'failed':
+                self.had_error = True
+            elif report.outcome == 'skipped':
+                self.was_skipped = True
         if hasattr(report, 'wasxfail'):
-            data['wasxfail'] = report.wasxfail
-        if hasattr(report.longrepr, 'reprcrash'):
-            data['message'] = report.longrepr.reprcrash.message
-        self.writer.write(data)
+            self.was_xfail = True
+            self.longrepr.append(
+                report.wasxfail if report.wasxfail else 'wasxfail')
+        self.sections = report.sections  # already accumulated over phases
+        if report.longrepr:
+            if hasattr(report.longrepr, 'reprcrash'):
+                self.longrepr.append(report.longrepr.reprcrash.message)
+            if isinstance(report.longrepr, tuple):
+                self.longrepr.append(report.longrepr[2])
+            elif isinstance(report.longrepr, str):
+                self.longrepr.append(report.longrepr)
+            else:
+                self.longrepr.append(str(report.longrepr))
 
+    def pytest_runtest_logfinish(self, nodeid, location):
+        """Called by pytest when the entire test is completed."""
+        if self.was_xfail:
+            if self.status == 'passed':
+                self.status = 'xpassed'
+            else: # 'skipped'
+                self.status = 'xfailed'
+        elif self.was_skipped:
+            self.status = 'skipped'
+        data = {'event': 'logreport',
+                'outcome': self.status,
+                'witherror': self.had_error,
+                'sections': self.sections,
+                'duration': self.duration,
+                'nodeid': nodeid,
+                'filename': location[0],
+                'lineno': location[1]}
+        if self.longrepr:
+            msg_lines = self.longrepr[0].rstrip().splitlines()
+            data['message'] = msg_lines[0]
+            start_item = 1 if len(msg_lines) == 1 else 0
+            data['longrepr'] = '\n'.join(self.longrepr[start_item:])
+        self.writer.write(data)
 
 def main(args):
     """Run pytest with the Spyder plugin."""

--- a/spyder_unittest/backend/pytestworker.py
+++ b/spyder_unittest/backend/pytestworker.py
@@ -97,8 +97,8 @@ class SpyderPlugin():
                 self.was_skipped = True
         if hasattr(report, 'wasxfail'):
             self.was_xfail = True
-            self.longrepr.append(
-                report.wasxfail if report.wasxfail else 'wasxfail')
+            self.longrepr.append(report.wasxfail if report.wasxfail else _(
+                'WAS EXPECTED TO FAIL'))
         self.sections = report.sections  # already accumulated over phases
         if report.longrepr:
             first_msg_idx = len(self.longrepr)

--- a/spyder_unittest/backend/tests/test_pytestworker.py
+++ b/spyder_unittest/backend/tests/test_pytestworker.py
@@ -30,12 +30,28 @@ def plugin():
     mock_writer = create_autospec(ZmqStreamWriter)
     return SpyderPlugin(mock_writer)
 
+
+@pytest.fixture
+def plugin_ini():
+    mock_writer = create_autospec(ZmqStreamWriter)
+    plugin = SpyderPlugin(mock_writer)
+    plugin.status = '---'
+    plugin.duration = 0
+    plugin.longrepr = []
+    plugin.sections = []
+    plugin.had_error = False
+    plugin.was_skipped = False
+    plugin.was_xfail = False
+    return plugin
+
+
 def test_spyderplugin_test_collectreport_with_success(plugin):
     report = EmptyClass()
     report.outcome = 'success'
     report.nodeid = 'foo.py::bar'
     plugin.pytest_collectreport(report)
     plugin.writer.write.assert_not_called()
+
 
 def test_spyderplugin_test_collectreport_with_failure(plugin):
     report = EmptyClass()
@@ -50,6 +66,7 @@ def test_spyderplugin_test_collectreport_with_failure(plugin):
         'longrepr': 'message'
     })
 
+
 def test_spyderplugin_test_itemcollected(plugin):
     testitem = EmptyClass()
     testitem.nodeid = 'foo.py::bar'
@@ -59,6 +76,7 @@ def test_spyderplugin_test_itemcollected(plugin):
         'nodeid': 'foo.py::bar'
     })
 
+
 def standard_logreport():
     report = EmptyClass()
     report.when = 'call'
@@ -66,17 +84,113 @@ def standard_logreport():
     report.nodeid = 'foo.py::bar'
     report.duration = 42
     report.sections = []
-    report.longrepr = ''
+    report.longrepr = None
     report.location = ('foo.py', 24, 'bar')
     return report
 
-def test_spyderplugin_runtest_logreport(plugin):
+
+def test_pytest_runtest_logreport_passed(plugin_ini):
     report = standard_logreport()
-    plugin.pytest_runtest_logreport(report)
-    plugin.writer.write.assert_called_once_with({
+    report.sections = ['output']
+    plugin_ini.pytest_runtest_logreport(report)
+    assert plugin_ini.status == 'passed'
+    assert plugin_ini.duration == 42
+    assert plugin_ini.sections == ['output']
+    assert plugin_ini.had_error is False
+    assert plugin_ini.was_skipped is False
+    assert plugin_ini.was_xfail is False
+
+
+def test_pytest_runtest_logreport_failed(plugin_ini):
+    report = standard_logreport()
+    report.when = 'teardown'
+    report.outcome = 'failed'
+    plugin_ini.pytest_runtest_logreport(report)
+    assert plugin_ini.status == '---'
+    assert plugin_ini.duration == 0
+    assert plugin_ini.had_error is True
+    assert plugin_ini.was_skipped is False
+    assert plugin_ini.was_xfail is False
+
+
+def test_pytest_runtest_logreport_skipped(plugin_ini):
+    report = standard_logreport()
+    report.when = 'setup'
+    report.outcome = 'skipped'
+    plugin_ini.pytest_runtest_logreport(report)
+    assert plugin_ini.status == '---'
+    assert plugin_ini.duration == 0
+    assert plugin_ini.had_error is False
+    assert plugin_ini.was_skipped is True
+    assert plugin_ini.was_xfail is False
+
+
+@pytest.mark.parametrize('xfail_msg,longrepr', [
+    ('msg', 'msg'),
+    ('', 'wasxfail')
+])
+def test_pytest_runtest_logreport_xfail(plugin_ini, xfail_msg, longrepr):
+    report = standard_logreport()
+    report.wasxfail = xfail_msg
+    plugin_ini.pytest_runtest_logreport(report)
+    assert plugin_ini.status == 'passed'
+    assert plugin_ini.duration == 42
+    assert plugin_ini.had_error is False
+    assert plugin_ini.was_skipped is False
+    assert plugin_ini.was_xfail is True
+    assert plugin_ini.longrepr == [longrepr]
+
+
+def test_pytest_runtest_logreport_with_reprcrash_longrepr(plugin_ini):
+    class MockLongrepr:
+        def __init__(self):
+            self.reprcrash = EmptyClass()
+            self.reprcrash.message = 'msg'
+
+        def __str__(self):
+            return 'reprtraceback'
+
+    report = standard_logreport()
+    report.longrepr = MockLongrepr()
+    plugin_ini.pytest_runtest_logreport(report)
+    assert plugin_ini.longrepr == ['msg', 'reprtraceback']
+
+
+def test_pytest_runtest_logreport_with_tuple_longrepr(plugin_ini):
+    report = standard_logreport()
+    report.longrepr = ('path', 'lineno', 'msg')
+    plugin_ini.pytest_runtest_logreport(report)
+    assert plugin_ini.longrepr == ['msg']
+
+
+def test_pytest_runtest_logreport_with_str_longrepr(plugin_ini):
+    report = standard_logreport()
+    report.longrepr = 'msg'
+    plugin_ini.pytest_runtest_logreport(report)
+    assert plugin_ini.longrepr == ['msg']
+
+
+def test_pytest_runtest_logreport_with_excinfo_longrepr(plugin_ini):
+    class MockLongrepr:
+        def __str__(self):
+            return 'msg'
+
+    report = standard_logreport()
+    report.longrepr = MockLongrepr()
+    plugin_ini.pytest_runtest_logreport(report)
+    assert plugin_ini.longrepr == ['msg']
+
+
+def test_pytest_runtest_logfinish_skipped(plugin_ini):
+    nodeid = 'foo.py::bar'
+    location = ('foo.py', 24)
+    plugin_ini.was_skipped = True
+    plugin_ini.duration = 42
+    plugin_ini.pytest_runtest_logfinish(nodeid, location)
+    plugin_ini.writer.write.assert_called_once_with({
         'event': 'logreport',
-        'when': 'call',
-        'outcome': 'passed',
+        'outcome': 'skipped',
+        'witherror': False,
         'nodeid': 'foo.py::bar',
         'duration': 42,
         'sections': [],
@@ -84,83 +198,73 @@ def test_spyderplugin_runtest_logreport(plugin):
         'lineno': 24
     })
 
-def test_spyderplugin_runtest_logreport_passes_longrepr(plugin):
-    report = standard_logreport()
-    report.longrepr = 15
-    plugin.pytest_runtest_logreport(report)
-    plugin.writer.write.assert_called_once_with({
+
+def test_pytest_runtest_logfinish_xfailed(plugin_ini):
+    nodeid = 'foo.py::bar'
+    location = ('foo.py', 24)
+    plugin_ini.was_xfail = True
+    plugin_ini.status = 'skipped'
+    plugin_ini.duration = 42
+    plugin_ini.pytest_runtest_logfinish(nodeid, location)
+    plugin_ini.writer.write.assert_called_once_with({
         'event': 'logreport',
-        'when': 'call',
+        'outcome': 'xfailed',
+        'witherror': False,
+        'nodeid': 'foo.py::bar',
+        'duration': 42,
+        'sections': [],
+        'filename': 'foo.py',
+        'lineno': 24
+    })
+
+
+def test_pytest_runtest_logfinish_xpassed(plugin_ini):
+    nodeid = 'foo.py::bar'
+    location = ('foo.py', 24)
+    plugin_ini.was_xfail = True
+    plugin_ini.status = 'passed'
+    plugin_ini.duration = 42
+    plugin_ini.pytest_runtest_logfinish(nodeid, location)
+    plugin_ini.writer.write.assert_called_once_with({
+        'event': 'logreport',
+        'outcome': 'xpassed',
+        'witherror': False,
+        'nodeid': 'foo.py::bar',
+        'duration': 42,
+        'sections': [],
+        'filename': 'foo.py',
+        'lineno': 24
+    })
+
+
+@pytest.mark.parametrize('self_longrepr,message,longrepr', [
+    (['msg1 line1'], 'msg1 line1', ''),
+    (['msg1 line1\nmsg1 line2'], 'msg1 line1', 'msg1 line1\nmsg1 line2'),
+    (['msg1 line1', 'msg2'], 'msg1 line1', 'msg2'),
+    (['msg1 line1\nmsg1 line2', 'msg2'], 'msg1 line1',
+     'msg1 line1\nmsg1 line2\nmsg2'),
+])
+def test_pytest_runtest_logfinish_handles_longrepr(plugin_ini, self_longrepr,
+                                                   message, longrepr):
+    nodeid = 'foo.py::bar'
+    location = ('foo.py', 24)
+    plugin_ini.status = 'passed'
+    plugin_ini.duration = 42
+    plugin_ini.longrepr = self_longrepr
+    plugin_ini.pytest_runtest_logfinish(nodeid, location)
+    plugin_ini.writer.write.assert_called_once_with({
+        'event': 'logreport',
         'outcome': 'passed',
+        'witherror': False,
         'nodeid': 'foo.py::bar',
         'duration': 42,
         'sections': [],
         'filename': 'foo.py',
         'lineno': 24,
-        'longrepr': '15'
+        'message': message,
+        'longrepr': longrepr
     })
 
-def test_spyderplugin_runtest_logreport_with_longrepr_tuple(plugin):
-    report = standard_logreport()
-    report.longrepr = ('ham', 'spam')
-    plugin.pytest_runtest_logreport(report)
-    plugin.writer.write.assert_called_once_with({
-        'event': 'logreport',
-        'when': 'call',
-        'outcome': 'passed',
-        'nodeid': 'foo.py::bar',
-        'duration': 42,
-        'sections': [],
-        'filename': 'foo.py',
-        'lineno': 24,
-        'longrepr': ('ham', 'spam')
-    })
-
-def test_spyderplugin_runtest_logreport_passes_wasxfail(plugin):
-    report = standard_logreport()
-    report.wasxfail = ''
-    plugin.pytest_runtest_logreport(report)
-    plugin.writer.write.assert_called_once_with({
-        'event': 'logreport',
-        'when': 'call',
-        'outcome': 'passed',
-        'nodeid': 'foo.py::bar',
-        'duration': 42,
-        'sections': [],
-        'filename': 'foo.py',
-        'lineno': 24,
-        'wasxfail': ''
-    })
-
-def test_spyderplugin_runtest_logreport_passes_message(plugin):
-    class MockLongrepr:
-        def __init__(self):
-            self.reprcrash = EmptyClass()
-            self.reprcrash.message = 'msg'
-        def __str__(self):
-            return 'text'
-
-    report = standard_logreport()
-    report.longrepr = MockLongrepr()
-    plugin.pytest_runtest_logreport(report)
-    plugin.writer.write.assert_called_once_with({
-        'event': 'logreport',
-        'when': 'call',
-        'outcome': 'passed',
-        'nodeid': 'foo.py::bar',
-        'duration': 42,
-        'sections': [],
-        'filename': 'foo.py',
-        'lineno': 24,
-        'longrepr': 'text',
-        'message': 'msg'
-    })
-
-def test_spyderplugin_runtest_logreport_ignores_teardown_passed(plugin):
-    report = standard_logreport()
-    report.when = 'teardown'
-    plugin.pytest_runtest_logreport(report)
-    plugin.writer.write.assert_not_called()
 
 def test_pytestworker_integration(monkeypatch, tmpdir):
     os.chdir(tmpdir.strpath)
@@ -188,8 +292,8 @@ def test_pytestworker_integration(monkeypatch, tmpdir):
     assert args[2][0][0]['nodeid'] == 'test_foo.py::test_ok'
 
     assert args[3][0][0]['event'] == 'logreport'
-    assert args[3][0][0]['when'] == 'call'
     assert args[3][0][0]['outcome'] == 'passed'
+    assert args[3][0][0]['witherror'] is False
     assert args[3][0][0]['nodeid'] == 'test_foo.py::test_ok'
     assert args[3][0][0]['sections'] == []
     assert args[3][0][0]['filename'] == 'test_foo.py'
@@ -200,8 +304,8 @@ def test_pytestworker_integration(monkeypatch, tmpdir):
     assert args[4][0][0]['nodeid'] == 'test_foo.py::test_fail'
 
     assert args[5][0][0]['event'] == 'logreport'
-    assert args[5][0][0]['when'] == 'call'
     assert args[5][0][0]['outcome'] == 'failed'
+    assert args[5][0][0]['witherror'] is False
     assert args[5][0][0]['nodeid'] == 'test_foo.py::test_fail'
     assert args[5][0][0]['sections'] == []
     assert args[5][0][0]['filename'] == 'test_foo.py'

--- a/spyder_unittest/backend/tests/test_pytestworker.py
+++ b/spyder_unittest/backend/tests/test_pytestworker.py
@@ -127,7 +127,7 @@ def test_pytest_runtest_logreport_skipped(plugin_ini):
 
 @pytest.mark.parametrize('xfail_msg,longrepr', [
     ('msg', 'msg'),
-    ('', 'wasxfail')
+    ('', 'WAS EXPECTED TO FAIL')
 ])
 def test_pytest_runtest_logreport_xfail(plugin_ini, xfail_msg, longrepr):
     report = standard_logreport()

--- a/spyder_unittest/widgets/tests/test_unittestgui.py
+++ b/spyder_unittest/widgets/tests/test_unittestgui.py
@@ -181,11 +181,13 @@ def test_run_tests_and_display_results(qtbot, tmpdir, monkeypatch, framework):
     MockQMessageBox.assert_not_called()
     model = widget.testdatamodel
     assert model.rowCount() == 2
-    assert model.index(0, 0).data(Qt.DisplayRole) == 'ok'
+    assert model.index(0, 0).data(
+        Qt.DisplayRole) == 'ok' if framework == 'nose' else 'passed'
     assert model.index(0, 1).data(Qt.DisplayRole) == 't.test_ok'
     assert model.index(0, 1).data(Qt.ToolTipRole) == 'test_foo.test_ok'
     assert model.index(0, 2).data(Qt.DisplayRole) == ''
-    assert model.index(1, 0).data(Qt.DisplayRole) == 'failure'
+    assert model.index(1, 0).data(
+        Qt.DisplayRole) == 'failure' if framework == 'nose' else 'failed'
     assert model.index(1, 1).data(Qt.DisplayRole) == 't.test_fail'
     assert model.index(1, 1).data(Qt.ToolTipRole) == 'test_foo.test_fail'
 


### PR DESCRIPTION
 Refactor pytest backend

Instead of writing events for each phase (setup, call, teardown) of a
test (and eventually displaying them in the datatree widget) we now
accumulate results over the individual test phases and only then write
the final result of the entire test upon test completion using the
pytest_runtest_logfinish hook.

This ensures the following:
1) Capturing of output from the teardown phase even if it passes
   without an error. This fixes #127 .
2) Differentiating between the outcome of the test itself (the call
   phase) and the entire test as a whole. An error during teardown,
   for instance, used to overwrite the (potentially passed) test result
   of the call phase. Now we get a passed test with an error during
   teardown. So in the datatree widget, the test status (first column)
   is no longer 1:1 linked with the color of this line (see also 3)).
3) Better handling of xfailed and xpassed tests which now show the
   correct status `xfailed` or `xpassed` and are colored green and
   red respectively (instead of status `skipped` and gray color for
   both of them). This fixes #47.
4) Better messages: the first message, which is usually the most
   important one, will be placed in the message column of the datatree
   widget. Further messages will be _appended_ to the extra_text field
   (instead of overwriting messages from previous test phases). If the
   first message spans over multiple lines then only its first line
   will be displayed in the message column and the complete message
   will be repeated in the extra_text field for better readability.
   This improves the visual impression of the datatree widget so that
   each (collapsed) row is exactly one line high.

