### PR TITLE
Fix pytest output processing

### DIFF
--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -78,8 +78,6 @@ class PyTestRunner(RunnerBase):
             elif result_item['event'] == 'logreport':
                 testresult = logreport_to_testresult(result_item, self.config)
                 result_list.append(testresult)
-            elif result_item['event'] == 'finished':
-                self.output = result_item['stdout']
 
         if collected_list:
             self.sig_collected.emit(collected_list)

--- a/spyder_unittest/backend/tests/test_pytestrunner.py
+++ b/spyder_unittest/backend/tests/test_pytestrunner.py
@@ -104,6 +104,22 @@ def test_pytestrunner_process_output_with_starttest(qtbot):
     expected = ['ham.spam.ham', 'ham.eggs.bacon']
     assert blocker.args == [expected]
 
+
+@pytest.mark.parametrize('output,results', [
+    ('== 1 passed in 0.10s ==', None),
+    ('== no tests ran 0.01s ==', [])
+])
+def test_pytestrunner_finished(qtbot, output, results):
+    mock_reader = Mock()
+    mock_reader.close = lambda: None
+    runner = PyTestRunner(None)
+    runner.reader = mock_reader
+    runner.read_all_process_output = lambda: output
+    with qtbot.waitSignal(runner.sig_finished) as blocker:
+        runner.finished()
+    assert blocker.args == [results, output]
+
+
 def standard_logreport_output():
     return {
         'event': 'logreport',


### PR DESCRIPTION
Just some small code maintenance:

1. remove unused code:
The `'finished'` event is processed nowhere. Process output is obtained by `read_all_process_output` instead.

2. add unit test for `pytestrunner_finished`:
This function was only tested in the integration test. I forgot to add a unit test when changing this function in 35469b5dec6.