### PR TITLE
PR: Require Python 3.5 or later

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
     packages=find_packages(),
     package_data={LIBNAME: get_package_data(LIBNAME, EXTLIST)},
     keywords=["Qt PyQt4 PyQt5 spyder plugins testing"],
+    python_requires='>=3.5',
     install_requires=REQUIREMENTS,
     url='https://github.com/spyder-ide/spyder-unittest',
     license='MIT',
@@ -69,10 +70,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Testing',
         'Topic :: Text Editors :: Integrated Development Environments (IDE)'])

--- a/spyder_unittest/unittestplugin.py
+++ b/spyder_unittest/unittestplugin.py
@@ -13,7 +13,7 @@ from qtpy.QtWidgets import QVBoxLayout
 from spyder.api.plugins import SpyderPluginWidget
 from spyder.config.base import get_translation
 from spyder.config.gui import is_dark_interface
-from spyder.py3compat import getcwd
+from spyder.py3compat import PY2, getcwd
 from spyder.utils import icon_manager as ima
 from spyder.utils.qthelpers import create_action
 
@@ -216,6 +216,27 @@ class UnitTestPlugin(SpyderPluginWidget):
     def apply_plugin_settings(self, options):
         """Apply configuration file's plugin settings."""
         pass
+
+    def check_compatibility(self):
+        """
+        Check compatibility of the plugin.
+
+        This checks that the plugin is not run under Python 2.
+
+        Returns
+        -------
+        (bool, str)
+            The first value tells Spyder if the plugin has passed the
+            compatibility test defined in this method. The second value
+            is a message that must explain users why the plugin was
+            found to be incompatible (e.g. 'This plugin does not work
+            with PyQt4'). It will be shown at startup in a QMessageBox.
+        """
+        if PY2:
+            msg = _('The unittest plugin does not work with Python 2.')
+            return (False, msg)
+        else:
+            return (True, '')
 
     # ----- Public API --------------------------------------------------------
     def maybe_configure_and_start(self):

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -20,15 +20,21 @@ from spyder.config.base import get_conf_path, get_translation
 from spyder.utils import icon_manager as ima
 from spyder.utils.qthelpers import create_action, create_toolbutton
 from spyder.plugins.variableexplorer.widgets.texteditor import TextEditor
+from spyder.py3compat import PY3
 
 # Local imports
 from spyder_unittest.backend.frameworkregistry import FrameworkRegistry
 from spyder_unittest.backend.noserunner import NoseRunner
-from spyder_unittest.backend.pytestrunner import PyTestRunner
 from spyder_unittest.backend.runnerbase import Category, TestResult
 from spyder_unittest.backend.unittestrunner import UnittestRunner
 from spyder_unittest.widgets.configdialog import Config, ask_for_config
 from spyder_unittest.widgets.datatree import TestDataModel, TestDataView
+
+# This import uses Python 3 syntax, so importing it under Python 2 throws
+# a SyntaxError which means that the plugin's check_compatibility method
+# will never run.
+if PY3:
+    from spyder_unittest.backend.pytestrunner import PyTestRunner
 
 # This is needed for testing this module as a stand alone script
 try:
@@ -38,7 +44,10 @@ except KeyError:
     _ = gettext.gettext
 
 # Supported testing framework
-FRAMEWORKS = {NoseRunner, PyTestRunner, UnittestRunner}
+if PY3:
+    FRAMEWORKS = {NoseRunner, PyTestRunner, UnittestRunner}
+else:
+    FRAMEWORKS = {NoseRunner, UnittestRunner}
 
 
 class UnitTestWidget(QWidget):


### PR DESCRIPTION
In particular, this drops support for Python 2.

This is only a minimal PR. Another PR targetting a major release of the plugin will remove all Python 2 specific code.

Fixes #154.