### PR TITLE
PR: Add code coverage report

### DIFF
--- a/spyder_unittest/backend/noserunner.py
+++ b/spyder_unittest/backend/noserunner.py
@@ -39,12 +39,13 @@ class NoseRunner(RunnerBase):
                     "   {} {}".format(ep.dist.project_name, ep.dist.version))
         return versions
 
-    def create_argument_list(self, config):
+    def create_argument_list(self, config, cov_path):
         """Create argument list for testing process."""
         return [
             '-m', self.module, '--with-xunit',
-            '--xunit-file={}'.format(self.resultfilename)
-        ] + (["--with-coverage"] if config.coverage else [])
+            '--xunit-file={}'.format(self.resultfilename),
+        ] + (['--with-coverage', f'--cover-package={cov_path}']
+             if config.coverage else [])
 
     def finished(self):
         """Called when the unit test process has finished."""

--- a/spyder_unittest/backend/noserunner.py
+++ b/spyder_unittest/backend/noserunner.py
@@ -39,12 +39,12 @@ class NoseRunner(RunnerBase):
                     "   {} {}".format(ep.dist.project_name, ep.dist.version))
         return versions
 
-    def create_argument_list(self):
+    def create_argument_list(self, config):
         """Create argument list for testing process."""
         return [
             '-m', self.module, '--with-xunit',
             '--xunit-file={}'.format(self.resultfilename)
-        ]
+        ] + (["--with-coverage"] if config.coverage else [])
 
     def finished(self):
         """Called when the unit test process has finished."""

--- a/spyder_unittest/backend/noserunner.py
+++ b/spyder_unittest/backend/noserunner.py
@@ -44,8 +44,7 @@ class NoseRunner(RunnerBase):
         return [
             '-m', self.module, '--with-xunit',
             '--xunit-file={}'.format(self.resultfilename),
-        ] + (['--with-coverage', f'--cover-package={cov_path}']
-             if config.coverage else [])
+            ]
 
     def finished(self):
         """Called when the unit test process has finished."""

--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -12,7 +12,6 @@ import os.path as osp
 # Local imports
 from spyder_unittest.backend.runnerbase import Category, RunnerBase, TestResult
 from spyder_unittest.backend.zmqstream import ZmqStreamReader
-from spyder.py3compat import getcwd
 
 
 class PyTestRunner(RunnerBase):
@@ -45,7 +44,7 @@ class PyTestRunner(RunnerBase):
         """Create argument list for testing process."""
         pyfile = os.path.join(os.path.dirname(__file__), 'pytestworker.py')
         return [pyfile, str(self.reader.port)] + (
-            [f"--cov={getcwd()}", "--cov-report=term-missing"]
+            ["--cov=", "--cov-report=term-missing"]
             if config.coverage else [])
 
     def start(self, config, pythonpath):

--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -98,8 +98,10 @@ class PyTestRunner(RunnerBase):
 
         Called by the function 'finished' at the very end.
         """
+        # coverage report columns:
+        # Name  Stmts   Miss  Cover   Missing
         cov_results = re.search(
-            r'(-*? coverage:.*?---------------\nTOTAL\s.*?\s(\d*?)\%.*)\n====',
+            r'(-*? coverage:.*?-*\nTOTAL\s.*?\s(\d*?)\%.*)\n=*',
             output, flags=re.S)
         if cov_results:
             cov = cov_results.group(2)
@@ -116,10 +118,13 @@ class PyTestRunner(RunnerBase):
             for row in re.findall(
                     r'^((.*?\.py) .*?(\d+%).*?(\d[\d\,\-\ ]*)?)$',
                     cov_results.group(0), flags=re.M):
+                lineno = (int(re.search(r'^(\d*)', row[3]).group(1)) - 1
+                          if row[3] else None)
                 file_cov = TestResult(
                     Category.COVERAGE, row[2], row[1],
                     message=f'Missing: {row[3] if row[3] else "(none)"}',
-                    extra_text=f'{header}\n{row[0]}', filename=row[1])
+                    extra_text=f'{header}\n{row[0]}', filename=row[1],
+                    lineno=lineno)
                 self.sig_collected.emit([row[1]])
                 self.sig_testresult.emit([file_cov])
 

--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -105,23 +105,22 @@ class PyTestRunner(RunnerBase):
 
         Called by the function 'finished' at the very end.
         """
-        # coverage report columns:
-        # Name  Stmts   Miss  Cover   Missing
         cov_results = re.search(
-            r'(-*? coverage:.*?-*\nTOTAL\s.*?\s(\d*?)\%.*)\n=*',
+            r'-*? coverage:.*?-*\nTOTAL\s.*?\s(\d*?)\%.*\n=*',
             output, flags=re.S)
         if cov_results:
-            cov = cov_results.group(2)
-            cov_text = cov_results.group(1)
+            total_coverage = cov_results.group(1)
             cov_report = TestResult(
-                Category.COVERAGE, f'{cov}%', _(COV_TEST_NAME),
-                extra_text=_(cov_text))
+                Category.COVERAGE, f'{total_coverage}%', _(COV_TEST_NAME))
             # create a fake test, then emit the coverage as the result
+            # This gives overall test coverage, used in TestDataModel.summary
             self.sig_collected.emit([COV_TEST_NAME])
             self.sig_testresult.emit([cov_report])
 
             # also build a result for each file's coverage
             header = "".join(cov_results.group(0).split("\n")[1:3])
+            # coverage report columns:
+            # Name  Stmts   Miss  Cover   Missing
             for row in re.findall(
                     r'^((.*?\.py) .*?(\d+%).*?(\d[\d\,\-\ ]*)?)$',
                     cov_results.group(0), flags=re.M):

--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -40,19 +40,19 @@ class PyTestRunner(RunnerBase):
                     plugins=[GetPluginVersionsPlugin()])
         return versions
 
-    def create_argument_list(self, config):
+    def create_argument_list(self, config, cov_path):
         """Create argument list for testing process."""
         pyfile = os.path.join(os.path.dirname(__file__), 'pytestworker.py')
         return [pyfile, str(self.reader.port)] + (
-            ["--cov=", "--cov-report=term-missing"]
+            [f"--cov={cov_path}", "--cov-report=term-missing"]
             if config.coverage else [])
 
-    def start(self, config, pythonpath):
+    def start(self, config, cov_path, pythonpath):
         """Start process which will run the unit test suite."""
         self.config = config
         self.reader = ZmqStreamReader()
         self.reader.sig_received.connect(self.process_output)
-        RunnerBase.start(self, config, pythonpath)
+        RunnerBase.start(self, config, cov_path, pythonpath)
 
     def process_output(self, output):
         """

--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -52,9 +52,11 @@ class PyTestRunner(RunnerBase):
     def create_argument_list(self, config, cov_path):
         """Create argument list for testing process."""
         pyfile = os.path.join(os.path.dirname(__file__), 'pytestworker.py')
-        return [pyfile, str(self.reader.port)] + (
-            [f'--cov={cov_path}', '--cov-report=term-missing']
-            if config.coverage else [])
+        arguments = [pyfile, str(self.reader.port)]
+        if config.coverage:
+            arguments += [f'--cov={cov_path}', '--cov-report=term-missing']
+        return arguments
+
 
     def start(self, config, cov_path, executable, pythonpath):
         """Start process which will run the unit test suite."""

--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -113,11 +113,12 @@ class PyTestRunner(RunnerBase):
 
             # also build a result for each file's coverage
             header = "".join(cov_results.group(0).split("\n")[1:3])
-            for row in re.findall(r'^((.*?\.py) .*?(\d+%).*?(\d[\d\,\-\ ]*))$',
-                                  cov_results.group(0), flags=re.M):
+            for row in re.findall(
+                    r'^((.*?\.py) .*?(\d+%).*?(\d[\d\,\-\ ]*)?)$',
+                    cov_results.group(0), flags=re.M):
                 file_cov = TestResult(
                     Category.COVERAGE, row[2], row[1],
-                    message=f'Missing: {row[3]}',
+                    message=f'Missing: {row[3] if row[3] else "(none)"}',
                     extra_text=f'{header}\n{row[0]}', filename=row[1])
                 self.sig_collected.emit([row[1]])
                 self.sig_testresult.emit([file_cov])

--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -12,6 +12,7 @@ import os.path as osp
 # Local imports
 from spyder_unittest.backend.runnerbase import Category, RunnerBase, TestResult
 from spyder_unittest.backend.zmqstream import ZmqStreamReader
+from spyder.py3compat import getcwd
 
 
 class PyTestRunner(RunnerBase):
@@ -40,10 +41,12 @@ class PyTestRunner(RunnerBase):
                     plugins=[GetPluginVersionsPlugin()])
         return versions
 
-    def create_argument_list(self):
+    def create_argument_list(self, config):
         """Create argument list for testing process."""
         pyfile = os.path.join(os.path.dirname(__file__), 'pytestworker.py')
-        return [pyfile, str(self.reader.port)]
+        return [pyfile, str(self.reader.port)] + (
+            [f"--cov={getcwd()}", "--cov-report=term-missing"]
+            if config.coverage else [])
 
     def start(self, config, pythonpath):
         """Start process which will run the unit test suite."""

--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -11,9 +11,16 @@ import os.path as osp
 import re
 
 # Local imports
+from spyder.config.base import get_translation
 from spyder_unittest.backend.runnerbase import (Category, RunnerBase,
                                                 TestResult, COV_TEST_NAME)
 from spyder_unittest.backend.zmqstream import ZmqStreamReader
+
+try:
+    _ = get_translation('spyder_unittest')
+except KeyError:
+    import gettext
+    _ = gettext.gettext
 
 
 class PyTestRunner(RunnerBase):
@@ -107,8 +114,8 @@ class PyTestRunner(RunnerBase):
             cov = cov_results.group(2)
             cov_text = cov_results.group(1)
             cov_report = TestResult(
-                Category.COVERAGE, f'{cov}%', COV_TEST_NAME,
-                extra_text=cov_text)
+                Category.COVERAGE, f'{cov}%', _(COV_TEST_NAME),
+                extra_text=_(cov_text))
             # create a fake test, then emit the coverage as the result
             self.sig_collected.emit([COV_TEST_NAME])
             self.sig_testresult.emit([cov_report])
@@ -122,8 +129,8 @@ class PyTestRunner(RunnerBase):
                           if row[3] else None)
                 file_cov = TestResult(
                     Category.COVERAGE, row[2], row[1],
-                    message=f'Missing: {row[3] if row[3] else "(none)"}',
-                    extra_text=f'{header}\n{row[0]}', filename=row[1],
+                    message=_(f'Missing: {row[3] if row[3] else "(none)"}'),
+                    extra_text=_(f'{header}\n{row[0]}'), filename=row[1],
                     lineno=lineno)
                 self.sig_collected.emit([row[1]])
                 self.sig_testresult.emit([file_cov])

--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -113,7 +113,7 @@ class PyTestRunner(RunnerBase):
         if cov_results:
             total_coverage = cov_results.group(1)
             cov_report = TestResult(
-                Category.COVERAGE, f'{total_coverage}%', _(COV_TEST_NAME))
+                Category.COVERAGE, f'{total_coverage}%', COV_TEST_NAME)
             # create a fake test, then emit the coverage as the result
             # This gives overall test coverage, used in TestDataModel.summary
             self.sig_collected.emit([COV_TEST_NAME])
@@ -130,8 +130,8 @@ class PyTestRunner(RunnerBase):
                           if row[3] else None)
                 file_cov = TestResult(
                     Category.COVERAGE, row[2], row[1],
-                    message=_(f'Missing: {row[3] if row[3] else "(none)"}'),
-                    extra_text=_(f'{header}\n{row[0]}'), filename=row[1],
+                    message=_('Missing: {}').format(row[3] if row[3] else _("(none)")),
+                    extra_text=_('{}\n{}').format(header, row[0]), filename=row[1],
                     lineno=lineno)
                 self.sig_collected.emit([row[1]])
                 self.sig_testresult.emit([file_cov])

--- a/spyder_unittest/backend/runnerbase.py
+++ b/spyder_unittest/backend/runnerbase.py
@@ -20,6 +20,11 @@ except ImportError:  # Python 2
     from pkgutil import find_loader as find_spec_or_loader
 
 
+# if generating coverage report, use this name for the TestResult
+# it's here in case we can get coverage results from unittest too
+COV_TEST_NAME = 'Total Test Coverage'
+
+
 class Category:
     """Enum type representing category of test result."""
 
@@ -27,6 +32,7 @@ class Category:
     OK = 2
     SKIP = 3
     PENDING = 4
+    COVERAGE = 5
 
 
 class TestResult:

--- a/spyder_unittest/backend/runnerbase.py
+++ b/spyder_unittest/backend/runnerbase.py
@@ -161,7 +161,7 @@ class RunnerBase(QObject):
         """
         raise NotImplementedError
 
-    def create_argument_list(self, config):
+    def create_argument_list(self, config, cov_path):
         """
         Create argument list for testing process (dummy).
 
@@ -189,7 +189,7 @@ class RunnerBase(QObject):
             process.setProcessEnvironment(env)
         return process
 
-    def start(self, config, pythonpath):
+    def start(self, config, cov_path, pythonpath):
         """
         Start process which will run the unit test suite.
 
@@ -203,6 +203,8 @@ class RunnerBase(QObject):
         ----------
         config : TestConfig
             Unit test configuration.
+        cov_path : str or None
+            Path to filter source for coverage report
         pythonpath : list of str
             List of directories to be added to the Python path
 
@@ -213,7 +215,7 @@ class RunnerBase(QObject):
         """
         self.process = self._prepare_process(config, pythonpath)
         executable = get_python_executable()
-        p_args = self.create_argument_list(config)
+        p_args = self.create_argument_list(config, cov_path)
         try:
             os.remove(self.resultfilename)
         except OSError:

--- a/spyder_unittest/backend/runnerbase.py
+++ b/spyder_unittest/backend/runnerbase.py
@@ -161,7 +161,7 @@ class RunnerBase(QObject):
         """
         raise NotImplementedError
 
-    def create_argument_list(self):
+    def create_argument_list(self, config):
         """
         Create argument list for testing process (dummy).
 
@@ -213,7 +213,7 @@ class RunnerBase(QObject):
         """
         self.process = self._prepare_process(config, pythonpath)
         executable = get_python_executable()
-        p_args = self.create_argument_list()
+        p_args = self.create_argument_list(config)
         try:
             os.remove(self.resultfilename)
         except OSError:

--- a/spyder_unittest/backend/tests/test_pytestrunner.py
+++ b/spyder_unittest/backend/tests/test_pytestrunner.py
@@ -70,6 +70,7 @@ def test_pytestrunner_start(monkeypatch):
         runner, config, cov_path, ['pythondir'])
 
 
+@pytest.mark.skip("segfaulting for some reason")
 def test_pytestrunner_process_output_with_collected(qtbot):
     runner = PyTestRunner(None)
     output = [{'event': 'collected', 'nodeid': 'spam.py::ham'},

--- a/spyder_unittest/backend/tests/test_pytestrunner.py
+++ b/spyder_unittest/backend/tests/test_pytestrunner.py
@@ -31,6 +31,7 @@ def test_pytestrunner_is_installed():
 
 def test_pytestrunner_create_argument_list(monkeypatch):
     config = Config()
+    cov_path = None
     MockZMQStreamReader = Mock()
     monkeypatch.setattr(
         'spyder_unittest.backend.pytestrunner.ZmqStreamReader',
@@ -41,7 +42,7 @@ def test_pytestrunner_create_argument_list(monkeypatch):
     runner.reader = mock_reader
     monkeypatch.setattr('spyder_unittest.backend.pytestrunner.os.path.dirname',
                         lambda _: 'dir')
-    pyfile, port, *coverage = runner.create_argument_list(config)
+    pyfile, port, *coverage = runner.create_argument_list(config, cov_path)
     assert pyfile == 'dir{}pytestworker.py'.format(os.sep)
     assert port == '42'
 
@@ -59,12 +60,14 @@ def test_pytestrunner_start(monkeypatch):
 
     runner = PyTestRunner(None, 'results')
     config = Config()
-    runner.start(config, ['pythondir'])
+    cov_path = None
+    runner.start(config, cov_path, ['pythondir'])
     assert runner.config is config
     assert runner.reader is mock_reader
     runner.reader.sig_received.connect.assert_called_once_with(
         runner.process_output)
-    MockRunnerBase.start.assert_called_once_with(runner, config, ['pythondir'])
+    MockRunnerBase.start.assert_called_once_with(
+        runner, config, cov_path, ['pythondir'])
 
 
 def test_pytestrunner_process_output_with_collected(qtbot):

--- a/spyder_unittest/backend/tests/test_pytestrunner.py
+++ b/spyder_unittest/backend/tests/test_pytestrunner.py
@@ -70,7 +70,6 @@ def test_pytestrunner_start(monkeypatch):
         runner, config, cov_path, ['pythondir'])
 
 
-@pytest.mark.skip("segfaulting for some reason")
 def test_pytestrunner_process_output_with_collected(qtbot):
     runner = PyTestRunner(None)
     output = [{'event': 'collected', 'nodeid': 'spam.py::ham'},

--- a/spyder_unittest/backend/tests/test_pytestrunner.py
+++ b/spyder_unittest/backend/tests/test_pytestrunner.py
@@ -30,6 +30,7 @@ def test_pytestrunner_is_installed():
 
 
 def test_pytestrunner_create_argument_list(monkeypatch):
+    config = Config()
     MockZMQStreamReader = Mock()
     monkeypatch.setattr(
         'spyder_unittest.backend.pytestrunner.ZmqStreamReader',
@@ -40,7 +41,7 @@ def test_pytestrunner_create_argument_list(monkeypatch):
     runner.reader = mock_reader
     monkeypatch.setattr('spyder_unittest.backend.pytestrunner.os.path.dirname',
                         lambda _: 'dir')
-    pyfile, port = runner.create_argument_list()
+    pyfile, port, *coverage = runner.create_argument_list(config)
     assert pyfile == 'dir{}pytestworker.py'.format(os.sep)
     assert port == '42'
 

--- a/spyder_unittest/backend/tests/test_runnerbase.py
+++ b/spyder_unittest/backend/tests/test_runnerbase.py
@@ -82,8 +82,8 @@ def test_runnerbase_start(monkeypatch):
 
     runner = RunnerBase(None, 'results')
     runner._prepare_process = lambda c, p: mock_process
-    runner.create_argument_list = lambda: ['arg1', 'arg2']
-    config = Config('pytest', 'wdir')
+    runner.create_argument_list = lambda c: ['arg1', 'arg2']
+    config = Config('pytest', 'wdir', False)
     mock_process.waitForStarted = lambda: False
     with pytest.raises(RuntimeError):
         runner.start(config, ['pythondir'])

--- a/spyder_unittest/backend/tests/test_runnerbase.py
+++ b/spyder_unittest/backend/tests/test_runnerbase.py
@@ -27,6 +27,18 @@ def test_runnerbase_with_nonexisting_module():
 
     assert not FooRunner.is_installed()
 
+    foo_runner = FooRunner(None)
+    config = Config(foo_runner.module, 'wdir', True)
+
+    with pytest.raises(NotImplementedError):
+        foo_runner.create_argument_list(config, 'cov_path')
+
+    with pytest.raises(NotImplementedError):
+        foo_runner.get_versions()
+
+    with pytest.raises(NotImplementedError):
+        foo_runner.finished()
+
 
 @pytest.mark.parametrize('pythonpath,env_pythonpath', [
     ([], None),
@@ -82,11 +94,12 @@ def test_runnerbase_start(monkeypatch):
 
     runner = RunnerBase(None, 'results')
     runner._prepare_process = lambda c, p: mock_process
-    runner.create_argument_list = lambda c: ['arg1', 'arg2']
+    runner.create_argument_list = lambda c, cp: ['arg1', 'arg2']
     config = Config('pytest', 'wdir', False)
+    cov_path = None
     mock_process.waitForStarted = lambda: False
     with pytest.raises(RuntimeError):
-        runner.start(config, ['pythondir'])
+        runner.start(config, cov_path, ['pythondir'])
 
     mock_process.start.assert_called_once_with('python', ['arg1', 'arg2'])
     mock_remove.assert_called_once_with('results')

--- a/spyder_unittest/backend/unittestrunner.py
+++ b/spyder_unittest/backend/unittestrunner.py
@@ -27,7 +27,7 @@ class UnittestRunner(RunnerBase):
         import platform
         return ['unittest {}'.format(platform.python_version())]
 
-    def create_argument_list(self, config):
+    def create_argument_list(self, config, cov_path):
         """Create argument list for testing process."""
         return ['-m', self.module, 'discover', '-v']
 

--- a/spyder_unittest/backend/unittestrunner.py
+++ b/spyder_unittest/backend/unittestrunner.py
@@ -27,7 +27,7 @@ class UnittestRunner(RunnerBase):
         import platform
         return ['unittest {}'.format(platform.python_version())]
 
-    def create_argument_list(self):
+    def create_argument_list(self, config):
         """Create argument list for testing process."""
         return ['-m', self.module, 'discover', '-v']
 

--- a/spyder_unittest/locale/de/LC_MESSAGES/spyder_unittest.po
+++ b/spyder_unittest/locale/de/LC_MESSAGES/spyder_unittest.po
@@ -1,21 +1,22 @@
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: spyder-unittest\n"
-"POT-Creation-Date: 2022-01-18 14:22+0000\n"
+"POT-Creation-Date: 2022-06-26 13:58-0600\n"
 "PO-Revision-Date: 2022-01-18 14:46\n"
 "Last-Translator: \n"
 "Language-Team: German\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: pygettext.py 1.5\n"
+"Language: de_DE\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Crowdin-Project: spyder-unittest\n"
-"X-Crowdin-Project-ID: 381839\n"
-"X-Crowdin-Language: de\n"
+"Generated-By: pygettext.py 1.5\n"
 "X-Crowdin-File: /master/spyder_unittest/locale/spyder_unittest.pot\n"
 "X-Crowdin-File-ID: 49\n"
-"Language: de_DE\n"
+"X-Crowdin-Language: de\n"
+"X-Crowdin-Project: spyder-unittest\n"
+"X-Crowdin-Project-ID: 381839\n"
 
 #: spyder_unittest/backend/noserunner.py:100
 msgid "Captured stdout"
@@ -25,109 +26,128 @@ msgstr ""
 msgid "Captured stderr"
 msgstr ""
 
-#: spyder_unittest/backend/pytestworker.py:107
-msgid "WAS EXPECTED TO FAIL"
+#: spyder_unittest/backend/pytestrunner.py:133
+msgid "(none)"
 msgstr ""
 
-#: spyder_unittest/backend/pytestworker.py:123
-msgid "ERROR at"
+#: spyder_unittest/backend/pytestrunner.py:133
+msgid "Missing: {}"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:58 spyder_unittest/widgets/unittestgui.py:138
+#: spyder_unittest/backend/pytestrunner.py:134
+msgid ""
+"{}\n"
+"{}"
+msgstr ""
+
+#: spyder_unittest/unittestplugin.py:60 spyder_unittest/widgets/unittestgui.py:138
 msgid "Unit testing"
 msgstr "Unit-Tests"
 
-#: spyder_unittest/unittestplugin.py:69
+#: spyder_unittest/unittestplugin.py:71
 msgid "Run test suites and view their results"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:92 spyder_unittest/unittestplugin.py:93 spyder_unittest/widgets/unittestgui.py:379
+#: spyder_unittest/unittestplugin.py:94 spyder_unittest/unittestplugin.py:95 spyder_unittest/widgets/unittestgui.py:384
 msgid "Run unit tests"
 msgstr "Unit-Tests ausführen"
 
-#: spyder_unittest/unittestplugin.py:118
+#: spyder_unittest/unittestplugin.py:120
 msgid "The unittest plugin does not work with Python 2."
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:61
+#: spyder_unittest/widgets/configdialog.py:66
 msgid "Configure tests"
 msgstr "Tests konfigurieren"
 
-#: spyder_unittest/widgets/configdialog.py:65
+#: spyder_unittest/widgets/configdialog.py:70
 msgid "Test framework"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:74 spyder_unittest/widgets/unittestgui.py:265
+#: spyder_unittest/widgets/configdialog.py:79 spyder_unittest/widgets/unittestgui.py:265
 msgid "not available"
 msgstr "nicht verfügbar"
 
-#: spyder_unittest/widgets/configdialog.py:83
+#: spyder_unittest/widgets/configdialog.py:88
+msgid "Include coverage report in output"
+msgstr ""
+
+#: spyder_unittest/widgets/configdialog.py:89
+msgid "Works only for pytest, requires pytest-cov"
+msgstr ""
+
+#: spyder_unittest/widgets/configdialog.py:99
 msgid "Directory from which to run tests"
 msgstr "Verzeichnis, aus dem Tests ausgeführt werden sollen"
 
-#: spyder_unittest/widgets/configdialog.py:89 spyder_unittest/widgets/configdialog.py:125
+#: spyder_unittest/widgets/configdialog.py:105 spyder_unittest/widgets/configdialog.py:151
 msgid "Select directory"
 msgstr "Verzeichnis auswählen"
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Message"
 msgstr "Nachricht"
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Name"
 msgstr "Name"
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Status"
 msgstr "Status"
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Time (ms)"
 msgstr "Zeit (ms)"
 
-#: spyder_unittest/widgets/datatree.py:145
+#: spyder_unittest/widgets/datatree.py:147
 msgid "Collapse"
 msgstr "Einklappen"
 
-#: spyder_unittest/widgets/datatree.py:148
+#: spyder_unittest/widgets/datatree.py:150
 msgid "Expand"
 msgstr "Ausklappen"
 
-#: spyder_unittest/widgets/datatree.py:153
+#: spyder_unittest/widgets/datatree.py:155
 msgid "Go to definition"
 msgstr "Zur Definition gehen"
 
-#: spyder_unittest/widgets/datatree.py:402
+#: spyder_unittest/widgets/datatree.py:407
 msgid "test"
 msgstr "Test"
 
-#: spyder_unittest/widgets/datatree.py:402
+#: spyder_unittest/widgets/datatree.py:407
 msgid "tests"
 msgstr "Tests"
 
-#: spyder_unittest/widgets/datatree.py:406
+#: spyder_unittest/widgets/datatree.py:411
 msgid "No results to show."
 msgstr "Keine anzuzeigenden Ergebnisse."
 
-#: spyder_unittest/widgets/datatree.py:411
+#: spyder_unittest/widgets/datatree.py:416
 msgid "collected {}"
 msgstr "{} gesammelt"
 
-#: spyder_unittest/widgets/datatree.py:412
+#: spyder_unittest/widgets/datatree.py:417
 msgid "{} failed"
 msgstr "{} fehlgeschlagen"
 
-#: spyder_unittest/widgets/datatree.py:413
+#: spyder_unittest/widgets/datatree.py:418
 msgid ", {} passed"
 msgstr ", {} bestanden"
 
-#: spyder_unittest/widgets/datatree.py:415
+#: spyder_unittest/widgets/datatree.py:420
 msgid ", {} other"
 msgstr ", {} andere"
 
-#: spyder_unittest/widgets/datatree.py:417
+#: spyder_unittest/widgets/datatree.py:422
 msgid ", {} pending"
 msgstr ", {} ausstehend"
+
+#: spyder_unittest/widgets/datatree.py:427
+#, fuzzy
+msgid ", {} coverage"
+msgstr ", {} andere"
 
 #: spyder_unittest/widgets/unittestgui.py:151
 msgid "Configure ..."
@@ -157,47 +177,46 @@ msgstr "Ausgabe der Unit-Tests"
 msgid "Versions of frameworks and their installed plugins:"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:348
+#: spyder_unittest/widgets/unittestgui.py:353
 msgid "Error"
 msgstr "Fehler"
 
-#: spyder_unittest/widgets/unittestgui.py:348
+#: spyder_unittest/widgets/unittestgui.py:353
 msgid "Process failed to start"
 msgstr "Prozess konnte nicht gestartet werden"
 
-#: spyder_unittest/widgets/unittestgui.py:351
+#: spyder_unittest/widgets/unittestgui.py:356
 msgid "Running tests ..."
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:372
+#: spyder_unittest/widgets/unittestgui.py:377
 msgid "Stop"
 msgstr "Stopp"
 
-#: spyder_unittest/widgets/unittestgui.py:373
+#: spyder_unittest/widgets/unittestgui.py:378
 msgid "Stop current test process"
 msgstr "Aktuellen Testprozess stoppen"
 
-#: spyder_unittest/widgets/unittestgui.py:378
+#: spyder_unittest/widgets/unittestgui.py:383
 msgid "Run tests"
 msgstr "Tests ausführen"
 
-#: spyder_unittest/widgets/unittestgui.py:411
+#: spyder_unittest/widgets/unittestgui.py:416
 msgid "not run"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:418 spyder_unittest/widgets/unittestgui.py:424
+#: spyder_unittest/widgets/unittestgui.py:423 spyder_unittest/widgets/unittestgui.py:429
 msgid "pending"
 msgstr "ausstehend"
 
-#: spyder_unittest/widgets/unittestgui.py:425
+#: spyder_unittest/widgets/unittestgui.py:430
 msgid "running"
 msgstr "läuft"
 
-#: spyder_unittest/widgets/unittestgui.py:431
+#: spyder_unittest/widgets/unittestgui.py:436
 msgid "failure"
 msgstr "Fehlschlag"
 
-#: spyder_unittest/widgets/unittestgui.py:432
+#: spyder_unittest/widgets/unittestgui.py:437
 msgid "collection error"
 msgstr ""
-

--- a/spyder_unittest/locale/es/LC_MESSAGES/spyder_unittest.po
+++ b/spyder_unittest/locale/es/LC_MESSAGES/spyder_unittest.po
@@ -1,21 +1,22 @@
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: spyder-unittest\n"
-"POT-Creation-Date: 2022-01-18 14:22+0000\n"
+"POT-Creation-Date: 2022-06-26 13:58-0600\n"
 "PO-Revision-Date: 2022-01-18 14:46\n"
 "Last-Translator: \n"
 "Language-Team: Spanish\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: pygettext.py 1.5\n"
+"Language: es_ES\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Crowdin-Project: spyder-unittest\n"
-"X-Crowdin-Project-ID: 381839\n"
-"X-Crowdin-Language: es-ES\n"
+"Generated-By: pygettext.py 1.5\n"
 "X-Crowdin-File: /master/spyder_unittest/locale/spyder_unittest.pot\n"
 "X-Crowdin-File-ID: 49\n"
-"Language: es_ES\n"
+"X-Crowdin-Language: es-ES\n"
+"X-Crowdin-Project: spyder-unittest\n"
+"X-Crowdin-Project-ID: 381839\n"
 
 #: spyder_unittest/backend/noserunner.py:100
 msgid "Captured stdout"
@@ -25,108 +26,126 @@ msgstr ""
 msgid "Captured stderr"
 msgstr ""
 
-#: spyder_unittest/backend/pytestworker.py:107
-msgid "WAS EXPECTED TO FAIL"
+#: spyder_unittest/backend/pytestrunner.py:133
+msgid "(none)"
 msgstr ""
 
-#: spyder_unittest/backend/pytestworker.py:123
-msgid "ERROR at"
+#: spyder_unittest/backend/pytestrunner.py:133
+msgid "Missing: {}"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:58 spyder_unittest/widgets/unittestgui.py:138
+#: spyder_unittest/backend/pytestrunner.py:134
+msgid ""
+"{}\n"
+"{}"
+msgstr ""
+
+#: spyder_unittest/unittestplugin.py:60 spyder_unittest/widgets/unittestgui.py:138
 msgid "Unit testing"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:69
+#: spyder_unittest/unittestplugin.py:71
 msgid "Run test suites and view their results"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:92 spyder_unittest/unittestplugin.py:93 spyder_unittest/widgets/unittestgui.py:379
+#: spyder_unittest/unittestplugin.py:94 spyder_unittest/unittestplugin.py:95 spyder_unittest/widgets/unittestgui.py:384
 msgid "Run unit tests"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:118
+#: spyder_unittest/unittestplugin.py:120
 msgid "The unittest plugin does not work with Python 2."
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:61
+#: spyder_unittest/widgets/configdialog.py:66
 msgid "Configure tests"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:65
+#: spyder_unittest/widgets/configdialog.py:70
 msgid "Test framework"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:74 spyder_unittest/widgets/unittestgui.py:265
+#: spyder_unittest/widgets/configdialog.py:79 spyder_unittest/widgets/unittestgui.py:265
 msgid "not available"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:83
+#: spyder_unittest/widgets/configdialog.py:88
+msgid "Include coverage report in output"
+msgstr ""
+
+#: spyder_unittest/widgets/configdialog.py:89
+msgid "Works only for pytest, requires pytest-cov"
+msgstr ""
+
+#: spyder_unittest/widgets/configdialog.py:99
 msgid "Directory from which to run tests"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:89 spyder_unittest/widgets/configdialog.py:125
+#: spyder_unittest/widgets/configdialog.py:105 spyder_unittest/widgets/configdialog.py:151
 msgid "Select directory"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Message"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Name"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Status"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Time (ms)"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:145
+#: spyder_unittest/widgets/datatree.py:147
 msgid "Collapse"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:148
+#: spyder_unittest/widgets/datatree.py:150
 msgid "Expand"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:153
+#: spyder_unittest/widgets/datatree.py:155
 msgid "Go to definition"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:402
+#: spyder_unittest/widgets/datatree.py:407
 msgid "test"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:402
+#: spyder_unittest/widgets/datatree.py:407
 msgid "tests"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:406
+#: spyder_unittest/widgets/datatree.py:411
 msgid "No results to show."
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:411
+#: spyder_unittest/widgets/datatree.py:416
 msgid "collected {}"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:412
+#: spyder_unittest/widgets/datatree.py:417
 msgid "{} failed"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:413
+#: spyder_unittest/widgets/datatree.py:418
 msgid ", {} passed"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:415
+#: spyder_unittest/widgets/datatree.py:420
 msgid ", {} other"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:417
+#: spyder_unittest/widgets/datatree.py:422
 msgid ", {} pending"
+msgstr ""
+
+#: spyder_unittest/widgets/datatree.py:427
+msgid ", {} coverage"
 msgstr ""
 
 #: spyder_unittest/widgets/unittestgui.py:151
@@ -157,47 +176,46 @@ msgstr ""
 msgid "Versions of frameworks and their installed plugins:"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:348
+#: spyder_unittest/widgets/unittestgui.py:353
 msgid "Error"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:348
+#: spyder_unittest/widgets/unittestgui.py:353
 msgid "Process failed to start"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:351
+#: spyder_unittest/widgets/unittestgui.py:356
 msgid "Running tests ..."
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:372
+#: spyder_unittest/widgets/unittestgui.py:377
 msgid "Stop"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:373
+#: spyder_unittest/widgets/unittestgui.py:378
 msgid "Stop current test process"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:378
+#: spyder_unittest/widgets/unittestgui.py:383
 msgid "Run tests"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:411
+#: spyder_unittest/widgets/unittestgui.py:416
 msgid "not run"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:418 spyder_unittest/widgets/unittestgui.py:424
+#: spyder_unittest/widgets/unittestgui.py:423 spyder_unittest/widgets/unittestgui.py:429
 msgid "pending"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:425
+#: spyder_unittest/widgets/unittestgui.py:430
 msgid "running"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:431
+#: spyder_unittest/widgets/unittestgui.py:436
 msgid "failure"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:432
+#: spyder_unittest/widgets/unittestgui.py:437
 msgid "collection error"
 msgstr ""
-

--- a/spyder_unittest/locale/fr/LC_MESSAGES/spyder_unittest.po
+++ b/spyder_unittest/locale/fr/LC_MESSAGES/spyder_unittest.po
@@ -1,21 +1,22 @@
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: spyder-unittest\n"
-"POT-Creation-Date: 2022-01-18 14:22+0000\n"
+"POT-Creation-Date: 2022-06-26 13:58-0600\n"
 "PO-Revision-Date: 2022-01-18 14:46\n"
 "Last-Translator: \n"
 "Language-Team: French\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: pygettext.py 1.5\n"
+"Language: fr_FR\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"X-Crowdin-Project: spyder-unittest\n"
-"X-Crowdin-Project-ID: 381839\n"
-"X-Crowdin-Language: fr\n"
+"Generated-By: pygettext.py 1.5\n"
 "X-Crowdin-File: /master/spyder_unittest/locale/spyder_unittest.pot\n"
 "X-Crowdin-File-ID: 49\n"
-"Language: fr_FR\n"
+"X-Crowdin-Language: fr\n"
+"X-Crowdin-Project: spyder-unittest\n"
+"X-Crowdin-Project-ID: 381839\n"
 
 #: spyder_unittest/backend/noserunner.py:100
 msgid "Captured stdout"
@@ -25,109 +26,128 @@ msgstr "Stdout récupéré"
 msgid "Captured stderr"
 msgstr "Stderr récupéré"
 
-#: spyder_unittest/backend/pytestworker.py:107
-msgid "WAS EXPECTED TO FAIL"
+#: spyder_unittest/backend/pytestrunner.py:133
+msgid "(none)"
 msgstr ""
 
-#: spyder_unittest/backend/pytestworker.py:123
-msgid "ERROR at"
+#: spyder_unittest/backend/pytestrunner.py:133
+msgid "Missing: {}"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:58 spyder_unittest/widgets/unittestgui.py:138
+#: spyder_unittest/backend/pytestrunner.py:134
+msgid ""
+"{}\n"
+"{}"
+msgstr ""
+
+#: spyder_unittest/unittestplugin.py:60 spyder_unittest/widgets/unittestgui.py:138
 msgid "Unit testing"
 msgstr "Tests unitaires"
 
-#: spyder_unittest/unittestplugin.py:69
+#: spyder_unittest/unittestplugin.py:71
 msgid "Run test suites and view their results"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:92 spyder_unittest/unittestplugin.py:93 spyder_unittest/widgets/unittestgui.py:379
+#: spyder_unittest/unittestplugin.py:94 spyder_unittest/unittestplugin.py:95 spyder_unittest/widgets/unittestgui.py:384
 msgid "Run unit tests"
 msgstr "Lancement des tests unitaires"
 
-#: spyder_unittest/unittestplugin.py:118
+#: spyder_unittest/unittestplugin.py:120
 msgid "The unittest plugin does not work with Python 2."
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:61
+#: spyder_unittest/widgets/configdialog.py:66
 msgid "Configure tests"
 msgstr "Configurer les tests"
 
-#: spyder_unittest/widgets/configdialog.py:65
+#: spyder_unittest/widgets/configdialog.py:70
 msgid "Test framework"
 msgstr "Système de test"
 
-#: spyder_unittest/widgets/configdialog.py:74 spyder_unittest/widgets/unittestgui.py:265
+#: spyder_unittest/widgets/configdialog.py:79 spyder_unittest/widgets/unittestgui.py:265
 msgid "not available"
 msgstr "non disponible"
 
-#: spyder_unittest/widgets/configdialog.py:83
+#: spyder_unittest/widgets/configdialog.py:88
+msgid "Include coverage report in output"
+msgstr ""
+
+#: spyder_unittest/widgets/configdialog.py:89
+msgid "Works only for pytest, requires pytest-cov"
+msgstr ""
+
+#: spyder_unittest/widgets/configdialog.py:99
 msgid "Directory from which to run tests"
 msgstr "Répertoire depuis lequel exécuter les tests"
 
-#: spyder_unittest/widgets/configdialog.py:89 spyder_unittest/widgets/configdialog.py:125
+#: spyder_unittest/widgets/configdialog.py:105 spyder_unittest/widgets/configdialog.py:151
 msgid "Select directory"
 msgstr "Sélectionner un dossier"
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Message"
 msgstr "Message"
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Name"
 msgstr "Nom"
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Status"
 msgstr "État "
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Time (ms)"
 msgstr "Durée (ms)"
 
-#: spyder_unittest/widgets/datatree.py:145
+#: spyder_unittest/widgets/datatree.py:147
 msgid "Collapse"
 msgstr "Réduire"
 
-#: spyder_unittest/widgets/datatree.py:148
+#: spyder_unittest/widgets/datatree.py:150
 msgid "Expand"
 msgstr "Déployer"
 
-#: spyder_unittest/widgets/datatree.py:153
+#: spyder_unittest/widgets/datatree.py:155
 msgid "Go to definition"
 msgstr "Aller à la définition"
 
-#: spyder_unittest/widgets/datatree.py:402
+#: spyder_unittest/widgets/datatree.py:407
 msgid "test"
 msgstr "test"
 
-#: spyder_unittest/widgets/datatree.py:402
+#: spyder_unittest/widgets/datatree.py:407
 msgid "tests"
 msgstr "tests"
 
-#: spyder_unittest/widgets/datatree.py:406
+#: spyder_unittest/widgets/datatree.py:411
 msgid "No results to show."
 msgstr "Aucun résultat à afficher."
 
-#: spyder_unittest/widgets/datatree.py:411
+#: spyder_unittest/widgets/datatree.py:416
 msgid "collected {}"
 msgstr "{} collectés"
 
-#: spyder_unittest/widgets/datatree.py:412
+#: spyder_unittest/widgets/datatree.py:417
 msgid "{} failed"
 msgstr "{} échec"
 
-#: spyder_unittest/widgets/datatree.py:413
+#: spyder_unittest/widgets/datatree.py:418
 msgid ", {} passed"
 msgstr ", {} réussi"
 
-#: spyder_unittest/widgets/datatree.py:415
+#: spyder_unittest/widgets/datatree.py:420
 msgid ", {} other"
 msgstr ", {} autres"
 
-#: spyder_unittest/widgets/datatree.py:417
+#: spyder_unittest/widgets/datatree.py:422
 msgid ", {} pending"
 msgstr ", {} en cours"
+
+#: spyder_unittest/widgets/datatree.py:427
+#, fuzzy
+msgid ", {} coverage"
+msgstr ", {} autres"
 
 #: spyder_unittest/widgets/unittestgui.py:151
 msgid "Configure ..."
@@ -157,47 +177,46 @@ msgstr "Résultats de tests unitaires"
 msgid "Versions of frameworks and their installed plugins:"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:348
+#: spyder_unittest/widgets/unittestgui.py:353
 msgid "Error"
 msgstr "Erreur"
 
-#: spyder_unittest/widgets/unittestgui.py:348
+#: spyder_unittest/widgets/unittestgui.py:353
 msgid "Process failed to start"
 msgstr "Le processus n'a pas pu démarrer"
 
-#: spyder_unittest/widgets/unittestgui.py:351
+#: spyder_unittest/widgets/unittestgui.py:356
 msgid "Running tests ..."
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:372
+#: spyder_unittest/widgets/unittestgui.py:377
 msgid "Stop"
 msgstr "Arrêter"
 
-#: spyder_unittest/widgets/unittestgui.py:373
+#: spyder_unittest/widgets/unittestgui.py:378
 msgid "Stop current test process"
 msgstr "Arrêter le processus de test en cours"
 
-#: spyder_unittest/widgets/unittestgui.py:378
+#: spyder_unittest/widgets/unittestgui.py:383
 msgid "Run tests"
 msgstr "Lancer les tests"
 
-#: spyder_unittest/widgets/unittestgui.py:411
+#: spyder_unittest/widgets/unittestgui.py:416
 msgid "not run"
 msgstr "non lancé"
 
-#: spyder_unittest/widgets/unittestgui.py:418 spyder_unittest/widgets/unittestgui.py:424
+#: spyder_unittest/widgets/unittestgui.py:423 spyder_unittest/widgets/unittestgui.py:429
 msgid "pending"
 msgstr "en attente"
 
-#: spyder_unittest/widgets/unittestgui.py:425
+#: spyder_unittest/widgets/unittestgui.py:430
 msgid "running"
 msgstr "en cours"
 
-#: spyder_unittest/widgets/unittestgui.py:431
+#: spyder_unittest/widgets/unittestgui.py:436
 msgid "failure"
 msgstr "échec"
 
-#: spyder_unittest/widgets/unittestgui.py:432
+#: spyder_unittest/widgets/unittestgui.py:437
 msgid "collection error"
 msgstr "erreur de collecte"
-

--- a/spyder_unittest/locale/hr/LC_MESSAGES/spyder_unittest.po
+++ b/spyder_unittest/locale/hr/LC_MESSAGES/spyder_unittest.po
@@ -1,21 +1,22 @@
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: spyder-unittest\n"
-"POT-Creation-Date: 2022-01-18 14:22+0000\n"
+"POT-Creation-Date: 2022-06-26 13:58-0600\n"
 "PO-Revision-Date: 2022-01-18 14:46\n"
 "Last-Translator: \n"
 "Language-Team: Croatian\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: pygettext.py 1.5\n"
+"Language: hr_HR\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
-"X-Crowdin-Project: spyder-unittest\n"
-"X-Crowdin-Project-ID: 381839\n"
-"X-Crowdin-Language: hr\n"
+"Generated-By: pygettext.py 1.5\n"
 "X-Crowdin-File: /master/spyder_unittest/locale/spyder_unittest.pot\n"
 "X-Crowdin-File-ID: 49\n"
-"Language: hr_HR\n"
+"X-Crowdin-Language: hr\n"
+"X-Crowdin-Project: spyder-unittest\n"
+"X-Crowdin-Project-ID: 381839\n"
 
 #: spyder_unittest/backend/noserunner.py:100
 msgid "Captured stdout"
@@ -25,108 +26,126 @@ msgstr ""
 msgid "Captured stderr"
 msgstr ""
 
-#: spyder_unittest/backend/pytestworker.py:107
-msgid "WAS EXPECTED TO FAIL"
+#: spyder_unittest/backend/pytestrunner.py:133
+msgid "(none)"
 msgstr ""
 
-#: spyder_unittest/backend/pytestworker.py:123
-msgid "ERROR at"
+#: spyder_unittest/backend/pytestrunner.py:133
+msgid "Missing: {}"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:58 spyder_unittest/widgets/unittestgui.py:138
+#: spyder_unittest/backend/pytestrunner.py:134
+msgid ""
+"{}\n"
+"{}"
+msgstr ""
+
+#: spyder_unittest/unittestplugin.py:60 spyder_unittest/widgets/unittestgui.py:138
 msgid "Unit testing"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:69
+#: spyder_unittest/unittestplugin.py:71
 msgid "Run test suites and view their results"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:92 spyder_unittest/unittestplugin.py:93 spyder_unittest/widgets/unittestgui.py:379
+#: spyder_unittest/unittestplugin.py:94 spyder_unittest/unittestplugin.py:95 spyder_unittest/widgets/unittestgui.py:384
 msgid "Run unit tests"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:118
+#: spyder_unittest/unittestplugin.py:120
 msgid "The unittest plugin does not work with Python 2."
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:61
+#: spyder_unittest/widgets/configdialog.py:66
 msgid "Configure tests"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:65
+#: spyder_unittest/widgets/configdialog.py:70
 msgid "Test framework"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:74 spyder_unittest/widgets/unittestgui.py:265
+#: spyder_unittest/widgets/configdialog.py:79 spyder_unittest/widgets/unittestgui.py:265
 msgid "not available"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:83
+#: spyder_unittest/widgets/configdialog.py:88
+msgid "Include coverage report in output"
+msgstr ""
+
+#: spyder_unittest/widgets/configdialog.py:89
+msgid "Works only for pytest, requires pytest-cov"
+msgstr ""
+
+#: spyder_unittest/widgets/configdialog.py:99
 msgid "Directory from which to run tests"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:89 spyder_unittest/widgets/configdialog.py:125
+#: spyder_unittest/widgets/configdialog.py:105 spyder_unittest/widgets/configdialog.py:151
 msgid "Select directory"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Message"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Name"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Status"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Time (ms)"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:145
+#: spyder_unittest/widgets/datatree.py:147
 msgid "Collapse"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:148
+#: spyder_unittest/widgets/datatree.py:150
 msgid "Expand"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:153
+#: spyder_unittest/widgets/datatree.py:155
 msgid "Go to definition"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:402
+#: spyder_unittest/widgets/datatree.py:407
 msgid "test"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:402
+#: spyder_unittest/widgets/datatree.py:407
 msgid "tests"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:406
+#: spyder_unittest/widgets/datatree.py:411
 msgid "No results to show."
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:411
+#: spyder_unittest/widgets/datatree.py:416
 msgid "collected {}"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:412
+#: spyder_unittest/widgets/datatree.py:417
 msgid "{} failed"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:413
+#: spyder_unittest/widgets/datatree.py:418
 msgid ", {} passed"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:415
+#: spyder_unittest/widgets/datatree.py:420
 msgid ", {} other"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:417
+#: spyder_unittest/widgets/datatree.py:422
 msgid ", {} pending"
+msgstr ""
+
+#: spyder_unittest/widgets/datatree.py:427
+msgid ", {} coverage"
 msgstr ""
 
 #: spyder_unittest/widgets/unittestgui.py:151
@@ -157,47 +176,46 @@ msgstr ""
 msgid "Versions of frameworks and their installed plugins:"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:348
+#: spyder_unittest/widgets/unittestgui.py:353
 msgid "Error"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:348
+#: spyder_unittest/widgets/unittestgui.py:353
 msgid "Process failed to start"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:351
+#: spyder_unittest/widgets/unittestgui.py:356
 msgid "Running tests ..."
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:372
+#: spyder_unittest/widgets/unittestgui.py:377
 msgid "Stop"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:373
+#: spyder_unittest/widgets/unittestgui.py:378
 msgid "Stop current test process"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:378
+#: spyder_unittest/widgets/unittestgui.py:383
 msgid "Run tests"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:411
+#: spyder_unittest/widgets/unittestgui.py:416
 msgid "not run"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:418 spyder_unittest/widgets/unittestgui.py:424
+#: spyder_unittest/widgets/unittestgui.py:423 spyder_unittest/widgets/unittestgui.py:429
 msgid "pending"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:425
+#: spyder_unittest/widgets/unittestgui.py:430
 msgid "running"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:431
+#: spyder_unittest/widgets/unittestgui.py:436
 msgid "failure"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:432
+#: spyder_unittest/widgets/unittestgui.py:437
 msgid "collection error"
 msgstr ""
-

--- a/spyder_unittest/locale/hu/LC_MESSAGES/spyder_unittest.po
+++ b/spyder_unittest/locale/hu/LC_MESSAGES/spyder_unittest.po
@@ -1,21 +1,22 @@
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: spyder-unittest\n"
-"POT-Creation-Date: 2022-01-18 14:22+0000\n"
+"POT-Creation-Date: 2022-06-26 13:58-0600\n"
 "PO-Revision-Date: 2022-01-18 14:46\n"
 "Last-Translator: \n"
 "Language-Team: Hungarian\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: pygettext.py 1.5\n"
+"Language: hu_HU\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Crowdin-Project: spyder-unittest\n"
-"X-Crowdin-Project-ID: 381839\n"
-"X-Crowdin-Language: hu\n"
+"Generated-By: pygettext.py 1.5\n"
 "X-Crowdin-File: /master/spyder_unittest/locale/spyder_unittest.pot\n"
 "X-Crowdin-File-ID: 49\n"
-"Language: hu_HU\n"
+"X-Crowdin-Language: hu\n"
+"X-Crowdin-Project: spyder-unittest\n"
+"X-Crowdin-Project-ID: 381839\n"
 
 #: spyder_unittest/backend/noserunner.py:100
 msgid "Captured stdout"
@@ -25,108 +26,126 @@ msgstr ""
 msgid "Captured stderr"
 msgstr ""
 
-#: spyder_unittest/backend/pytestworker.py:107
-msgid "WAS EXPECTED TO FAIL"
+#: spyder_unittest/backend/pytestrunner.py:133
+msgid "(none)"
 msgstr ""
 
-#: spyder_unittest/backend/pytestworker.py:123
-msgid "ERROR at"
+#: spyder_unittest/backend/pytestrunner.py:133
+msgid "Missing: {}"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:58 spyder_unittest/widgets/unittestgui.py:138
+#: spyder_unittest/backend/pytestrunner.py:134
+msgid ""
+"{}\n"
+"{}"
+msgstr ""
+
+#: spyder_unittest/unittestplugin.py:60 spyder_unittest/widgets/unittestgui.py:138
 msgid "Unit testing"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:69
+#: spyder_unittest/unittestplugin.py:71
 msgid "Run test suites and view their results"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:92 spyder_unittest/unittestplugin.py:93 spyder_unittest/widgets/unittestgui.py:379
+#: spyder_unittest/unittestplugin.py:94 spyder_unittest/unittestplugin.py:95 spyder_unittest/widgets/unittestgui.py:384
 msgid "Run unit tests"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:118
+#: spyder_unittest/unittestplugin.py:120
 msgid "The unittest plugin does not work with Python 2."
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:61
+#: spyder_unittest/widgets/configdialog.py:66
 msgid "Configure tests"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:65
+#: spyder_unittest/widgets/configdialog.py:70
 msgid "Test framework"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:74 spyder_unittest/widgets/unittestgui.py:265
+#: spyder_unittest/widgets/configdialog.py:79 spyder_unittest/widgets/unittestgui.py:265
 msgid "not available"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:83
+#: spyder_unittest/widgets/configdialog.py:88
+msgid "Include coverage report in output"
+msgstr ""
+
+#: spyder_unittest/widgets/configdialog.py:89
+msgid "Works only for pytest, requires pytest-cov"
+msgstr ""
+
+#: spyder_unittest/widgets/configdialog.py:99
 msgid "Directory from which to run tests"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:89 spyder_unittest/widgets/configdialog.py:125
+#: spyder_unittest/widgets/configdialog.py:105 spyder_unittest/widgets/configdialog.py:151
 msgid "Select directory"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Message"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Name"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Status"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Time (ms)"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:145
+#: spyder_unittest/widgets/datatree.py:147
 msgid "Collapse"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:148
+#: spyder_unittest/widgets/datatree.py:150
 msgid "Expand"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:153
+#: spyder_unittest/widgets/datatree.py:155
 msgid "Go to definition"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:402
+#: spyder_unittest/widgets/datatree.py:407
 msgid "test"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:402
+#: spyder_unittest/widgets/datatree.py:407
 msgid "tests"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:406
+#: spyder_unittest/widgets/datatree.py:411
 msgid "No results to show."
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:411
+#: spyder_unittest/widgets/datatree.py:416
 msgid "collected {}"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:412
+#: spyder_unittest/widgets/datatree.py:417
 msgid "{} failed"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:413
+#: spyder_unittest/widgets/datatree.py:418
 msgid ", {} passed"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:415
+#: spyder_unittest/widgets/datatree.py:420
 msgid ", {} other"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:417
+#: spyder_unittest/widgets/datatree.py:422
 msgid ", {} pending"
+msgstr ""
+
+#: spyder_unittest/widgets/datatree.py:427
+msgid ", {} coverage"
 msgstr ""
 
 #: spyder_unittest/widgets/unittestgui.py:151
@@ -157,47 +176,46 @@ msgstr ""
 msgid "Versions of frameworks and their installed plugins:"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:348
+#: spyder_unittest/widgets/unittestgui.py:353
 msgid "Error"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:348
+#: spyder_unittest/widgets/unittestgui.py:353
 msgid "Process failed to start"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:351
+#: spyder_unittest/widgets/unittestgui.py:356
 msgid "Running tests ..."
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:372
+#: spyder_unittest/widgets/unittestgui.py:377
 msgid "Stop"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:373
+#: spyder_unittest/widgets/unittestgui.py:378
 msgid "Stop current test process"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:378
+#: spyder_unittest/widgets/unittestgui.py:383
 msgid "Run tests"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:411
+#: spyder_unittest/widgets/unittestgui.py:416
 msgid "not run"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:418 spyder_unittest/widgets/unittestgui.py:424
+#: spyder_unittest/widgets/unittestgui.py:423 spyder_unittest/widgets/unittestgui.py:429
 msgid "pending"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:425
+#: spyder_unittest/widgets/unittestgui.py:430
 msgid "running"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:431
+#: spyder_unittest/widgets/unittestgui.py:436
 msgid "failure"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:432
+#: spyder_unittest/widgets/unittestgui.py:437
 msgid "collection error"
 msgstr ""
-

--- a/spyder_unittest/locale/ja/LC_MESSAGES/spyder_unittest.po
+++ b/spyder_unittest/locale/ja/LC_MESSAGES/spyder_unittest.po
@@ -1,21 +1,22 @@
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: spyder-unittest\n"
-"POT-Creation-Date: 2022-01-18 14:22+0000\n"
+"POT-Creation-Date: 2022-06-26 13:58-0600\n"
 "PO-Revision-Date: 2022-01-18 14:46\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: pygettext.py 1.5\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Crowdin-Project: spyder-unittest\n"
-"X-Crowdin-Project-ID: 381839\n"
-"X-Crowdin-Language: ja\n"
+"Generated-By: pygettext.py 1.5\n"
 "X-Crowdin-File: /master/spyder_unittest/locale/spyder_unittest.pot\n"
 "X-Crowdin-File-ID: 49\n"
-"Language: ja_JP\n"
+"X-Crowdin-Language: ja\n"
+"X-Crowdin-Project: spyder-unittest\n"
+"X-Crowdin-Project-ID: 381839\n"
 
 #: spyder_unittest/backend/noserunner.py:100
 msgid "Captured stdout"
@@ -25,108 +26,126 @@ msgstr ""
 msgid "Captured stderr"
 msgstr ""
 
-#: spyder_unittest/backend/pytestworker.py:107
-msgid "WAS EXPECTED TO FAIL"
+#: spyder_unittest/backend/pytestrunner.py:133
+msgid "(none)"
 msgstr ""
 
-#: spyder_unittest/backend/pytestworker.py:123
-msgid "ERROR at"
+#: spyder_unittest/backend/pytestrunner.py:133
+msgid "Missing: {}"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:58 spyder_unittest/widgets/unittestgui.py:138
+#: spyder_unittest/backend/pytestrunner.py:134
+msgid ""
+"{}\n"
+"{}"
+msgstr ""
+
+#: spyder_unittest/unittestplugin.py:60 spyder_unittest/widgets/unittestgui.py:138
 msgid "Unit testing"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:69
+#: spyder_unittest/unittestplugin.py:71
 msgid "Run test suites and view their results"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:92 spyder_unittest/unittestplugin.py:93 spyder_unittest/widgets/unittestgui.py:379
+#: spyder_unittest/unittestplugin.py:94 spyder_unittest/unittestplugin.py:95 spyder_unittest/widgets/unittestgui.py:384
 msgid "Run unit tests"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:118
+#: spyder_unittest/unittestplugin.py:120
 msgid "The unittest plugin does not work with Python 2."
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:61
+#: spyder_unittest/widgets/configdialog.py:66
 msgid "Configure tests"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:65
+#: spyder_unittest/widgets/configdialog.py:70
 msgid "Test framework"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:74 spyder_unittest/widgets/unittestgui.py:265
+#: spyder_unittest/widgets/configdialog.py:79 spyder_unittest/widgets/unittestgui.py:265
 msgid "not available"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:83
+#: spyder_unittest/widgets/configdialog.py:88
+msgid "Include coverage report in output"
+msgstr ""
+
+#: spyder_unittest/widgets/configdialog.py:89
+msgid "Works only for pytest, requires pytest-cov"
+msgstr ""
+
+#: spyder_unittest/widgets/configdialog.py:99
 msgid "Directory from which to run tests"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:89 spyder_unittest/widgets/configdialog.py:125
+#: spyder_unittest/widgets/configdialog.py:105 spyder_unittest/widgets/configdialog.py:151
 msgid "Select directory"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Message"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Name"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Status"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Time (ms)"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:145
+#: spyder_unittest/widgets/datatree.py:147
 msgid "Collapse"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:148
+#: spyder_unittest/widgets/datatree.py:150
 msgid "Expand"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:153
+#: spyder_unittest/widgets/datatree.py:155
 msgid "Go to definition"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:402
+#: spyder_unittest/widgets/datatree.py:407
 msgid "test"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:402
+#: spyder_unittest/widgets/datatree.py:407
 msgid "tests"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:406
+#: spyder_unittest/widgets/datatree.py:411
 msgid "No results to show."
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:411
+#: spyder_unittest/widgets/datatree.py:416
 msgid "collected {}"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:412
+#: spyder_unittest/widgets/datatree.py:417
 msgid "{} failed"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:413
+#: spyder_unittest/widgets/datatree.py:418
 msgid ", {} passed"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:415
+#: spyder_unittest/widgets/datatree.py:420
 msgid ", {} other"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:417
+#: spyder_unittest/widgets/datatree.py:422
 msgid ", {} pending"
+msgstr ""
+
+#: spyder_unittest/widgets/datatree.py:427
+msgid ", {} coverage"
 msgstr ""
 
 #: spyder_unittest/widgets/unittestgui.py:151
@@ -157,47 +176,46 @@ msgstr ""
 msgid "Versions of frameworks and their installed plugins:"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:348
+#: spyder_unittest/widgets/unittestgui.py:353
 msgid "Error"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:348
+#: spyder_unittest/widgets/unittestgui.py:353
 msgid "Process failed to start"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:351
+#: spyder_unittest/widgets/unittestgui.py:356
 msgid "Running tests ..."
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:372
+#: spyder_unittest/widgets/unittestgui.py:377
 msgid "Stop"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:373
+#: spyder_unittest/widgets/unittestgui.py:378
 msgid "Stop current test process"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:378
+#: spyder_unittest/widgets/unittestgui.py:383
 msgid "Run tests"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:411
+#: spyder_unittest/widgets/unittestgui.py:416
 msgid "not run"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:418 spyder_unittest/widgets/unittestgui.py:424
+#: spyder_unittest/widgets/unittestgui.py:423 spyder_unittest/widgets/unittestgui.py:429
 msgid "pending"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:425
+#: spyder_unittest/widgets/unittestgui.py:430
 msgid "running"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:431
+#: spyder_unittest/widgets/unittestgui.py:436
 msgid "failure"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:432
+#: spyder_unittest/widgets/unittestgui.py:437
 msgid "collection error"
 msgstr ""
-

--- a/spyder_unittest/locale/pl/LC_MESSAGES/spyder_unittest.po
+++ b/spyder_unittest/locale/pl/LC_MESSAGES/spyder_unittest.po
@@ -1,21 +1,22 @@
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: spyder-unittest\n"
-"POT-Creation-Date: 2022-01-18 14:22+0000\n"
+"POT-Creation-Date: 2022-06-26 13:58-0600\n"
 "PO-Revision-Date: 2022-01-18 14:46\n"
 "Last-Translator: \n"
 "Language-Team: Polish\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: pygettext.py 1.5\n"
+"Language: pl_PL\n"
 "Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
-"X-Crowdin-Project: spyder-unittest\n"
-"X-Crowdin-Project-ID: 381839\n"
-"X-Crowdin-Language: pl\n"
+"Generated-By: pygettext.py 1.5\n"
 "X-Crowdin-File: /master/spyder_unittest/locale/spyder_unittest.pot\n"
 "X-Crowdin-File-ID: 49\n"
-"Language: pl_PL\n"
+"X-Crowdin-Language: pl\n"
+"X-Crowdin-Project: spyder-unittest\n"
+"X-Crowdin-Project-ID: 381839\n"
 
 #: spyder_unittest/backend/noserunner.py:100
 msgid "Captured stdout"
@@ -25,108 +26,126 @@ msgstr ""
 msgid "Captured stderr"
 msgstr ""
 
-#: spyder_unittest/backend/pytestworker.py:107
-msgid "WAS EXPECTED TO FAIL"
+#: spyder_unittest/backend/pytestrunner.py:133
+msgid "(none)"
 msgstr ""
 
-#: spyder_unittest/backend/pytestworker.py:123
-msgid "ERROR at"
+#: spyder_unittest/backend/pytestrunner.py:133
+msgid "Missing: {}"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:58 spyder_unittest/widgets/unittestgui.py:138
+#: spyder_unittest/backend/pytestrunner.py:134
+msgid ""
+"{}\n"
+"{}"
+msgstr ""
+
+#: spyder_unittest/unittestplugin.py:60 spyder_unittest/widgets/unittestgui.py:138
 msgid "Unit testing"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:69
+#: spyder_unittest/unittestplugin.py:71
 msgid "Run test suites and view their results"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:92 spyder_unittest/unittestplugin.py:93 spyder_unittest/widgets/unittestgui.py:379
+#: spyder_unittest/unittestplugin.py:94 spyder_unittest/unittestplugin.py:95 spyder_unittest/widgets/unittestgui.py:384
 msgid "Run unit tests"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:118
+#: spyder_unittest/unittestplugin.py:120
 msgid "The unittest plugin does not work with Python 2."
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:61
+#: spyder_unittest/widgets/configdialog.py:66
 msgid "Configure tests"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:65
+#: spyder_unittest/widgets/configdialog.py:70
 msgid "Test framework"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:74 spyder_unittest/widgets/unittestgui.py:265
+#: spyder_unittest/widgets/configdialog.py:79 spyder_unittest/widgets/unittestgui.py:265
 msgid "not available"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:83
+#: spyder_unittest/widgets/configdialog.py:88
+msgid "Include coverage report in output"
+msgstr ""
+
+#: spyder_unittest/widgets/configdialog.py:89
+msgid "Works only for pytest, requires pytest-cov"
+msgstr ""
+
+#: spyder_unittest/widgets/configdialog.py:99
 msgid "Directory from which to run tests"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:89 spyder_unittest/widgets/configdialog.py:125
+#: spyder_unittest/widgets/configdialog.py:105 spyder_unittest/widgets/configdialog.py:151
 msgid "Select directory"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Message"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Name"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Status"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Time (ms)"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:145
+#: spyder_unittest/widgets/datatree.py:147
 msgid "Collapse"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:148
+#: spyder_unittest/widgets/datatree.py:150
 msgid "Expand"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:153
+#: spyder_unittest/widgets/datatree.py:155
 msgid "Go to definition"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:402
+#: spyder_unittest/widgets/datatree.py:407
 msgid "test"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:402
+#: spyder_unittest/widgets/datatree.py:407
 msgid "tests"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:406
+#: spyder_unittest/widgets/datatree.py:411
 msgid "No results to show."
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:411
+#: spyder_unittest/widgets/datatree.py:416
 msgid "collected {}"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:412
+#: spyder_unittest/widgets/datatree.py:417
 msgid "{} failed"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:413
+#: spyder_unittest/widgets/datatree.py:418
 msgid ", {} passed"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:415
+#: spyder_unittest/widgets/datatree.py:420
 msgid ", {} other"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:417
+#: spyder_unittest/widgets/datatree.py:422
 msgid ", {} pending"
+msgstr ""
+
+#: spyder_unittest/widgets/datatree.py:427
+msgid ", {} coverage"
 msgstr ""
 
 #: spyder_unittest/widgets/unittestgui.py:151
@@ -157,47 +176,46 @@ msgstr ""
 msgid "Versions of frameworks and their installed plugins:"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:348
+#: spyder_unittest/widgets/unittestgui.py:353
 msgid "Error"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:348
+#: spyder_unittest/widgets/unittestgui.py:353
 msgid "Process failed to start"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:351
+#: spyder_unittest/widgets/unittestgui.py:356
 msgid "Running tests ..."
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:372
+#: spyder_unittest/widgets/unittestgui.py:377
 msgid "Stop"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:373
+#: spyder_unittest/widgets/unittestgui.py:378
 msgid "Stop current test process"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:378
+#: spyder_unittest/widgets/unittestgui.py:383
 msgid "Run tests"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:411
+#: spyder_unittest/widgets/unittestgui.py:416
 msgid "not run"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:418 spyder_unittest/widgets/unittestgui.py:424
+#: spyder_unittest/widgets/unittestgui.py:423 spyder_unittest/widgets/unittestgui.py:429
 msgid "pending"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:425
+#: spyder_unittest/widgets/unittestgui.py:430
 msgid "running"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:431
+#: spyder_unittest/widgets/unittestgui.py:436
 msgid "failure"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:432
+#: spyder_unittest/widgets/unittestgui.py:437
 msgid "collection error"
 msgstr ""
-

--- a/spyder_unittest/locale/pt_BR/LC_MESSAGES/spyder_unittest.po
+++ b/spyder_unittest/locale/pt_BR/LC_MESSAGES/spyder_unittest.po
@@ -1,21 +1,22 @@
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: spyder-unittest\n"
-"POT-Creation-Date: 2022-01-18 14:22+0000\n"
+"POT-Creation-Date: 2022-06-26 13:58-0600\n"
 "PO-Revision-Date: 2022-01-18 14:46\n"
 "Last-Translator: \n"
 "Language-Team: Portuguese, Brazilian\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: pygettext.py 1.5\n"
+"Language: pt_BR\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Crowdin-Project: spyder-unittest\n"
-"X-Crowdin-Project-ID: 381839\n"
-"X-Crowdin-Language: pt-BR\n"
+"Generated-By: pygettext.py 1.5\n"
 "X-Crowdin-File: /master/spyder_unittest/locale/spyder_unittest.pot\n"
 "X-Crowdin-File-ID: 49\n"
-"Language: pt_BR\n"
+"X-Crowdin-Language: pt-BR\n"
+"X-Crowdin-Project: spyder-unittest\n"
+"X-Crowdin-Project-ID: 381839\n"
 
 #: spyder_unittest/backend/noserunner.py:100
 msgid "Captured stdout"
@@ -25,109 +26,128 @@ msgstr "stdout capturado"
 msgid "Captured stderr"
 msgstr "stderr capturado"
 
-#: spyder_unittest/backend/pytestworker.py:107
-msgid "WAS EXPECTED TO FAIL"
+#: spyder_unittest/backend/pytestrunner.py:133
+msgid "(none)"
 msgstr ""
 
-#: spyder_unittest/backend/pytestworker.py:123
-msgid "ERROR at"
+#: spyder_unittest/backend/pytestrunner.py:133
+msgid "Missing: {}"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:58 spyder_unittest/widgets/unittestgui.py:138
+#: spyder_unittest/backend/pytestrunner.py:134
+msgid ""
+"{}\n"
+"{}"
+msgstr ""
+
+#: spyder_unittest/unittestplugin.py:60 spyder_unittest/widgets/unittestgui.py:138
 msgid "Unit testing"
 msgstr "Teste unitário"
 
-#: spyder_unittest/unittestplugin.py:69
+#: spyder_unittest/unittestplugin.py:71
 msgid "Run test suites and view their results"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:92 spyder_unittest/unittestplugin.py:93 spyder_unittest/widgets/unittestgui.py:379
+#: spyder_unittest/unittestplugin.py:94 spyder_unittest/unittestplugin.py:95 spyder_unittest/widgets/unittestgui.py:384
 msgid "Run unit tests"
 msgstr "Executar testes unitários"
 
-#: spyder_unittest/unittestplugin.py:118
+#: spyder_unittest/unittestplugin.py:120
 msgid "The unittest plugin does not work with Python 2."
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:61
+#: spyder_unittest/widgets/configdialog.py:66
 msgid "Configure tests"
 msgstr "Configurar testes"
 
-#: spyder_unittest/widgets/configdialog.py:65
+#: spyder_unittest/widgets/configdialog.py:70
 msgid "Test framework"
 msgstr "Testar framework"
 
-#: spyder_unittest/widgets/configdialog.py:74 spyder_unittest/widgets/unittestgui.py:265
+#: spyder_unittest/widgets/configdialog.py:79 spyder_unittest/widgets/unittestgui.py:265
 msgid "not available"
 msgstr "indisponível"
 
-#: spyder_unittest/widgets/configdialog.py:83
+#: spyder_unittest/widgets/configdialog.py:88
+msgid "Include coverage report in output"
+msgstr ""
+
+#: spyder_unittest/widgets/configdialog.py:89
+msgid "Works only for pytest, requires pytest-cov"
+msgstr ""
+
+#: spyder_unittest/widgets/configdialog.py:99
 msgid "Directory from which to run tests"
 msgstr "Diretório para execução dos testes"
 
-#: spyder_unittest/widgets/configdialog.py:89 spyder_unittest/widgets/configdialog.py:125
+#: spyder_unittest/widgets/configdialog.py:105 spyder_unittest/widgets/configdialog.py:151
 msgid "Select directory"
 msgstr "Selecione o diretório"
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Message"
 msgstr "Mensagem"
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Name"
 msgstr "Nome"
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Status"
 msgstr "Status"
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Time (ms)"
 msgstr "Tempo (ms)"
 
-#: spyder_unittest/widgets/datatree.py:145
+#: spyder_unittest/widgets/datatree.py:147
 msgid "Collapse"
 msgstr "Recolher"
 
-#: spyder_unittest/widgets/datatree.py:148
+#: spyder_unittest/widgets/datatree.py:150
 msgid "Expand"
 msgstr "Expandir"
 
-#: spyder_unittest/widgets/datatree.py:153
+#: spyder_unittest/widgets/datatree.py:155
 msgid "Go to definition"
 msgstr "Ir para definição"
 
-#: spyder_unittest/widgets/datatree.py:402
+#: spyder_unittest/widgets/datatree.py:407
 msgid "test"
 msgstr "teste"
 
-#: spyder_unittest/widgets/datatree.py:402
+#: spyder_unittest/widgets/datatree.py:407
 msgid "tests"
 msgstr "testes"
 
-#: spyder_unittest/widgets/datatree.py:406
+#: spyder_unittest/widgets/datatree.py:411
 msgid "No results to show."
 msgstr "Sem resultados para exibir."
 
-#: spyder_unittest/widgets/datatree.py:411
+#: spyder_unittest/widgets/datatree.py:416
 msgid "collected {}"
 msgstr "coletado {}"
 
-#: spyder_unittest/widgets/datatree.py:412
+#: spyder_unittest/widgets/datatree.py:417
 msgid "{} failed"
 msgstr "{} falhou"
 
-#: spyder_unittest/widgets/datatree.py:413
+#: spyder_unittest/widgets/datatree.py:418
 msgid ", {} passed"
 msgstr ", {} passou"
 
-#: spyder_unittest/widgets/datatree.py:415
+#: spyder_unittest/widgets/datatree.py:420
 msgid ", {} other"
 msgstr ", {} outro"
 
-#: spyder_unittest/widgets/datatree.py:417
+#: spyder_unittest/widgets/datatree.py:422
 msgid ", {} pending"
 msgstr ", {} pendente"
+
+#: spyder_unittest/widgets/datatree.py:427
+#, fuzzy
+msgid ", {} coverage"
+msgstr ", {} outro"
 
 #: spyder_unittest/widgets/unittestgui.py:151
 msgid "Configure ..."
@@ -157,47 +177,46 @@ msgstr "Saída do teste unitário"
 msgid "Versions of frameworks and their installed plugins:"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:348
+#: spyder_unittest/widgets/unittestgui.py:353
 msgid "Error"
 msgstr "Erro"
 
-#: spyder_unittest/widgets/unittestgui.py:348
+#: spyder_unittest/widgets/unittestgui.py:353
 msgid "Process failed to start"
 msgstr "O processo falhou ao iniciar"
 
-#: spyder_unittest/widgets/unittestgui.py:351
+#: spyder_unittest/widgets/unittestgui.py:356
 msgid "Running tests ..."
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:372
+#: spyder_unittest/widgets/unittestgui.py:377
 msgid "Stop"
 msgstr "Parar"
 
-#: spyder_unittest/widgets/unittestgui.py:373
+#: spyder_unittest/widgets/unittestgui.py:378
 msgid "Stop current test process"
 msgstr "Parar processo de teste atual"
 
-#: spyder_unittest/widgets/unittestgui.py:378
+#: spyder_unittest/widgets/unittestgui.py:383
 msgid "Run tests"
 msgstr "Executar testes"
 
-#: spyder_unittest/widgets/unittestgui.py:411
+#: spyder_unittest/widgets/unittestgui.py:416
 msgid "not run"
 msgstr "não executar"
 
-#: spyder_unittest/widgets/unittestgui.py:418 spyder_unittest/widgets/unittestgui.py:424
+#: spyder_unittest/widgets/unittestgui.py:423 spyder_unittest/widgets/unittestgui.py:429
 msgid "pending"
 msgstr "pendente"
 
-#: spyder_unittest/widgets/unittestgui.py:425
+#: spyder_unittest/widgets/unittestgui.py:430
 msgid "running"
 msgstr "executando"
 
-#: spyder_unittest/widgets/unittestgui.py:431
+#: spyder_unittest/widgets/unittestgui.py:436
 msgid "failure"
 msgstr "falha"
 
-#: spyder_unittest/widgets/unittestgui.py:432
+#: spyder_unittest/widgets/unittestgui.py:437
 msgid "collection error"
 msgstr "erro na compilação"
-

--- a/spyder_unittest/locale/ru/LC_MESSAGES/spyder_unittest.po
+++ b/spyder_unittest/locale/ru/LC_MESSAGES/spyder_unittest.po
@@ -1,21 +1,22 @@
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: spyder-unittest\n"
-"POT-Creation-Date: 2022-01-18 14:22+0000\n"
+"POT-Creation-Date: 2022-06-26 13:58-0600\n"
 "PO-Revision-Date: 2022-01-18 14:46\n"
 "Last-Translator: \n"
 "Language-Team: Russian\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: pygettext.py 1.5\n"
+"Language: ru_RU\n"
 "Plural-Forms: nplurals=4; plural=((n%10==1 && n%100!=11) ? 0 : ((n%10 >= 2 && n%10 <=4 && (n%100 < 12 || n%100 > 14)) ? 1 : ((n%10 == 0 || (n%10 >= 5 && n%10 <=9)) || (n%100 >= 11 && n%100 <= 14)) ? 2 : 3));\n"
-"X-Crowdin-Project: spyder-unittest\n"
-"X-Crowdin-Project-ID: 381839\n"
-"X-Crowdin-Language: ru\n"
+"Generated-By: pygettext.py 1.5\n"
 "X-Crowdin-File: /master/spyder_unittest/locale/spyder_unittest.pot\n"
 "X-Crowdin-File-ID: 49\n"
-"Language: ru_RU\n"
+"X-Crowdin-Language: ru\n"
+"X-Crowdin-Project: spyder-unittest\n"
+"X-Crowdin-Project-ID: 381839\n"
 
 #: spyder_unittest/backend/noserunner.py:100
 msgid "Captured stdout"
@@ -25,108 +26,126 @@ msgstr ""
 msgid "Captured stderr"
 msgstr ""
 
-#: spyder_unittest/backend/pytestworker.py:107
-msgid "WAS EXPECTED TO FAIL"
+#: spyder_unittest/backend/pytestrunner.py:133
+msgid "(none)"
 msgstr ""
 
-#: spyder_unittest/backend/pytestworker.py:123
-msgid "ERROR at"
+#: spyder_unittest/backend/pytestrunner.py:133
+msgid "Missing: {}"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:58 spyder_unittest/widgets/unittestgui.py:138
+#: spyder_unittest/backend/pytestrunner.py:134
+msgid ""
+"{}\n"
+"{}"
+msgstr ""
+
+#: spyder_unittest/unittestplugin.py:60 spyder_unittest/widgets/unittestgui.py:138
 msgid "Unit testing"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:69
+#: spyder_unittest/unittestplugin.py:71
 msgid "Run test suites and view their results"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:92 spyder_unittest/unittestplugin.py:93 spyder_unittest/widgets/unittestgui.py:379
+#: spyder_unittest/unittestplugin.py:94 spyder_unittest/unittestplugin.py:95 spyder_unittest/widgets/unittestgui.py:384
 msgid "Run unit tests"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:118
+#: spyder_unittest/unittestplugin.py:120
 msgid "The unittest plugin does not work with Python 2."
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:61
+#: spyder_unittest/widgets/configdialog.py:66
 msgid "Configure tests"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:65
+#: spyder_unittest/widgets/configdialog.py:70
 msgid "Test framework"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:74 spyder_unittest/widgets/unittestgui.py:265
+#: spyder_unittest/widgets/configdialog.py:79 spyder_unittest/widgets/unittestgui.py:265
 msgid "not available"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:83
+#: spyder_unittest/widgets/configdialog.py:88
+msgid "Include coverage report in output"
+msgstr ""
+
+#: spyder_unittest/widgets/configdialog.py:89
+msgid "Works only for pytest, requires pytest-cov"
+msgstr ""
+
+#: spyder_unittest/widgets/configdialog.py:99
 msgid "Directory from which to run tests"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:89 spyder_unittest/widgets/configdialog.py:125
+#: spyder_unittest/widgets/configdialog.py:105 spyder_unittest/widgets/configdialog.py:151
 msgid "Select directory"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Message"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Name"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Status"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Time (ms)"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:145
+#: spyder_unittest/widgets/datatree.py:147
 msgid "Collapse"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:148
+#: spyder_unittest/widgets/datatree.py:150
 msgid "Expand"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:153
+#: spyder_unittest/widgets/datatree.py:155
 msgid "Go to definition"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:402
+#: spyder_unittest/widgets/datatree.py:407
 msgid "test"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:402
+#: spyder_unittest/widgets/datatree.py:407
 msgid "tests"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:406
+#: spyder_unittest/widgets/datatree.py:411
 msgid "No results to show."
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:411
+#: spyder_unittest/widgets/datatree.py:416
 msgid "collected {}"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:412
+#: spyder_unittest/widgets/datatree.py:417
 msgid "{} failed"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:413
+#: spyder_unittest/widgets/datatree.py:418
 msgid ", {} passed"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:415
+#: spyder_unittest/widgets/datatree.py:420
 msgid ", {} other"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:417
+#: spyder_unittest/widgets/datatree.py:422
 msgid ", {} pending"
+msgstr ""
+
+#: spyder_unittest/widgets/datatree.py:427
+msgid ", {} coverage"
 msgstr ""
 
 #: spyder_unittest/widgets/unittestgui.py:151
@@ -157,47 +176,46 @@ msgstr ""
 msgid "Versions of frameworks and their installed plugins:"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:348
+#: spyder_unittest/widgets/unittestgui.py:353
 msgid "Error"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:348
+#: spyder_unittest/widgets/unittestgui.py:353
 msgid "Process failed to start"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:351
+#: spyder_unittest/widgets/unittestgui.py:356
 msgid "Running tests ..."
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:372
+#: spyder_unittest/widgets/unittestgui.py:377
 msgid "Stop"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:373
+#: spyder_unittest/widgets/unittestgui.py:378
 msgid "Stop current test process"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:378
+#: spyder_unittest/widgets/unittestgui.py:383
 msgid "Run tests"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:411
+#: spyder_unittest/widgets/unittestgui.py:416
 msgid "not run"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:418 spyder_unittest/widgets/unittestgui.py:424
+#: spyder_unittest/widgets/unittestgui.py:423 spyder_unittest/widgets/unittestgui.py:429
 msgid "pending"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:425
+#: spyder_unittest/widgets/unittestgui.py:430
 msgid "running"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:431
+#: spyder_unittest/widgets/unittestgui.py:436
 msgid "failure"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:432
+#: spyder_unittest/widgets/unittestgui.py:437
 msgid "collection error"
 msgstr ""
-

--- a/spyder_unittest/locale/spyder_unittest.pot
+++ b/spyder_unittest/locale/spyder_unittest.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-18 14:22+0000\n"
+"POT-Creation-Date: 2022-06-26 13:58-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,108 +22,126 @@ msgstr ""
 msgid "Captured stderr"
 msgstr ""
 
-#: spyder_unittest/backend/pytestworker.py:107
-msgid "WAS EXPECTED TO FAIL"
+#: spyder_unittest/backend/pytestrunner.py:133
+msgid "(none)"
 msgstr ""
 
-#: spyder_unittest/backend/pytestworker.py:123
-msgid "ERROR at"
+#: spyder_unittest/backend/pytestrunner.py:133
+msgid "Missing: {}"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:58 spyder_unittest/widgets/unittestgui.py:138
+#: spyder_unittest/backend/pytestrunner.py:134
+msgid ""
+"{}\n"
+"{}"
+msgstr ""
+
+#: spyder_unittest/unittestplugin.py:60 spyder_unittest/widgets/unittestgui.py:138
 msgid "Unit testing"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:69
+#: spyder_unittest/unittestplugin.py:71
 msgid "Run test suites and view their results"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:92 spyder_unittest/unittestplugin.py:93 spyder_unittest/widgets/unittestgui.py:379
+#: spyder_unittest/unittestplugin.py:94 spyder_unittest/unittestplugin.py:95 spyder_unittest/widgets/unittestgui.py:384
 msgid "Run unit tests"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:118
+#: spyder_unittest/unittestplugin.py:120
 msgid "The unittest plugin does not work with Python 2."
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:61
+#: spyder_unittest/widgets/configdialog.py:66
 msgid "Configure tests"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:65
+#: spyder_unittest/widgets/configdialog.py:70
 msgid "Test framework"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:74 spyder_unittest/widgets/unittestgui.py:265
+#: spyder_unittest/widgets/configdialog.py:79 spyder_unittest/widgets/unittestgui.py:265
 msgid "not available"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:83
+#: spyder_unittest/widgets/configdialog.py:88
+msgid "Include coverage report in output"
+msgstr ""
+
+#: spyder_unittest/widgets/configdialog.py:89
+msgid "Works only for pytest, requires pytest-cov"
+msgstr ""
+
+#: spyder_unittest/widgets/configdialog.py:99
 msgid "Directory from which to run tests"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:89 spyder_unittest/widgets/configdialog.py:125
+#: spyder_unittest/widgets/configdialog.py:105 spyder_unittest/widgets/configdialog.py:151
 msgid "Select directory"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Message"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Name"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Status"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Time (ms)"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:145
+#: spyder_unittest/widgets/datatree.py:147
 msgid "Collapse"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:148
+#: spyder_unittest/widgets/datatree.py:150
 msgid "Expand"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:153
+#: spyder_unittest/widgets/datatree.py:155
 msgid "Go to definition"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:402
+#: spyder_unittest/widgets/datatree.py:407
 msgid "test"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:402
+#: spyder_unittest/widgets/datatree.py:407
 msgid "tests"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:406
+#: spyder_unittest/widgets/datatree.py:411
 msgid "No results to show."
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:411
+#: spyder_unittest/widgets/datatree.py:416
 msgid "collected {}"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:412
+#: spyder_unittest/widgets/datatree.py:417
 msgid "{} failed"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:413
+#: spyder_unittest/widgets/datatree.py:418
 msgid ", {} passed"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:415
+#: spyder_unittest/widgets/datatree.py:420
 msgid ", {} other"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:417
+#: spyder_unittest/widgets/datatree.py:422
 msgid ", {} pending"
+msgstr ""
+
+#: spyder_unittest/widgets/datatree.py:427
+msgid ", {} coverage"
 msgstr ""
 
 #: spyder_unittest/widgets/unittestgui.py:151
@@ -154,46 +172,46 @@ msgstr ""
 msgid "Versions of frameworks and their installed plugins:"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:348
+#: spyder_unittest/widgets/unittestgui.py:353
 msgid "Error"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:348
+#: spyder_unittest/widgets/unittestgui.py:353
 msgid "Process failed to start"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:351
+#: spyder_unittest/widgets/unittestgui.py:356
 msgid "Running tests ..."
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:372
+#: spyder_unittest/widgets/unittestgui.py:377
 msgid "Stop"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:373
+#: spyder_unittest/widgets/unittestgui.py:378
 msgid "Stop current test process"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:378
+#: spyder_unittest/widgets/unittestgui.py:383
 msgid "Run tests"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:411
+#: spyder_unittest/widgets/unittestgui.py:416
 msgid "not run"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:418 spyder_unittest/widgets/unittestgui.py:424
+#: spyder_unittest/widgets/unittestgui.py:423 spyder_unittest/widgets/unittestgui.py:429
 msgid "pending"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:425
+#: spyder_unittest/widgets/unittestgui.py:430
 msgid "running"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:431
+#: spyder_unittest/widgets/unittestgui.py:436
 msgid "failure"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:432
+#: spyder_unittest/widgets/unittestgui.py:437
 msgid "collection error"
 msgstr ""

--- a/spyder_unittest/locale/zh_CN/LC_MESSAGES/spyder_unittest.po
+++ b/spyder_unittest/locale/zh_CN/LC_MESSAGES/spyder_unittest.po
@@ -1,21 +1,22 @@
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: spyder-unittest\n"
-"POT-Creation-Date: 2022-01-18 14:22+0000\n"
+"POT-Creation-Date: 2022-06-26 13:58-0600\n"
 "PO-Revision-Date: 2022-01-18 14:46\n"
 "Last-Translator: \n"
 "Language-Team: Chinese Simplified\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: pygettext.py 1.5\n"
+"Language: zh_CN\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Crowdin-Project: spyder-unittest\n"
-"X-Crowdin-Project-ID: 381839\n"
-"X-Crowdin-Language: zh-CN\n"
+"Generated-By: pygettext.py 1.5\n"
 "X-Crowdin-File: /master/spyder_unittest/locale/spyder_unittest.pot\n"
 "X-Crowdin-File-ID: 49\n"
-"Language: zh_CN\n"
+"X-Crowdin-Language: zh-CN\n"
+"X-Crowdin-Project: spyder-unittest\n"
+"X-Crowdin-Project-ID: 381839\n"
 
 #: spyder_unittest/backend/noserunner.py:100
 msgid "Captured stdout"
@@ -25,108 +26,126 @@ msgstr ""
 msgid "Captured stderr"
 msgstr ""
 
-#: spyder_unittest/backend/pytestworker.py:107
-msgid "WAS EXPECTED TO FAIL"
+#: spyder_unittest/backend/pytestrunner.py:133
+msgid "(none)"
 msgstr ""
 
-#: spyder_unittest/backend/pytestworker.py:123
-msgid "ERROR at"
+#: spyder_unittest/backend/pytestrunner.py:133
+msgid "Missing: {}"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:58 spyder_unittest/widgets/unittestgui.py:138
+#: spyder_unittest/backend/pytestrunner.py:134
+msgid ""
+"{}\n"
+"{}"
+msgstr ""
+
+#: spyder_unittest/unittestplugin.py:60 spyder_unittest/widgets/unittestgui.py:138
 msgid "Unit testing"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:69
+#: spyder_unittest/unittestplugin.py:71
 msgid "Run test suites and view their results"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:92 spyder_unittest/unittestplugin.py:93 spyder_unittest/widgets/unittestgui.py:379
+#: spyder_unittest/unittestplugin.py:94 spyder_unittest/unittestplugin.py:95 spyder_unittest/widgets/unittestgui.py:384
 msgid "Run unit tests"
 msgstr ""
 
-#: spyder_unittest/unittestplugin.py:118
+#: spyder_unittest/unittestplugin.py:120
 msgid "The unittest plugin does not work with Python 2."
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:61
+#: spyder_unittest/widgets/configdialog.py:66
 msgid "Configure tests"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:65
+#: spyder_unittest/widgets/configdialog.py:70
 msgid "Test framework"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:74 spyder_unittest/widgets/unittestgui.py:265
+#: spyder_unittest/widgets/configdialog.py:79 spyder_unittest/widgets/unittestgui.py:265
 msgid "not available"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:83
+#: spyder_unittest/widgets/configdialog.py:88
+msgid "Include coverage report in output"
+msgstr ""
+
+#: spyder_unittest/widgets/configdialog.py:89
+msgid "Works only for pytest, requires pytest-cov"
+msgstr ""
+
+#: spyder_unittest/widgets/configdialog.py:99
 msgid "Directory from which to run tests"
 msgstr ""
 
-#: spyder_unittest/widgets/configdialog.py:89 spyder_unittest/widgets/configdialog.py:125
+#: spyder_unittest/widgets/configdialog.py:105 spyder_unittest/widgets/configdialog.py:151
 msgid "Select directory"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Message"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Name"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Status"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:49
+#: spyder_unittest/widgets/datatree.py:51
 msgid "Time (ms)"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:145
+#: spyder_unittest/widgets/datatree.py:147
 msgid "Collapse"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:148
+#: spyder_unittest/widgets/datatree.py:150
 msgid "Expand"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:153
+#: spyder_unittest/widgets/datatree.py:155
 msgid "Go to definition"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:402
+#: spyder_unittest/widgets/datatree.py:407
 msgid "test"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:402
+#: spyder_unittest/widgets/datatree.py:407
 msgid "tests"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:406
+#: spyder_unittest/widgets/datatree.py:411
 msgid "No results to show."
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:411
+#: spyder_unittest/widgets/datatree.py:416
 msgid "collected {}"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:412
+#: spyder_unittest/widgets/datatree.py:417
 msgid "{} failed"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:413
+#: spyder_unittest/widgets/datatree.py:418
 msgid ", {} passed"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:415
+#: spyder_unittest/widgets/datatree.py:420
 msgid ", {} other"
 msgstr ""
 
-#: spyder_unittest/widgets/datatree.py:417
+#: spyder_unittest/widgets/datatree.py:422
 msgid ", {} pending"
+msgstr ""
+
+#: spyder_unittest/widgets/datatree.py:427
+msgid ", {} coverage"
 msgstr ""
 
 #: spyder_unittest/widgets/unittestgui.py:151
@@ -157,47 +176,46 @@ msgstr ""
 msgid "Versions of frameworks and their installed plugins:"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:348
+#: spyder_unittest/widgets/unittestgui.py:353
 msgid "Error"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:348
+#: spyder_unittest/widgets/unittestgui.py:353
 msgid "Process failed to start"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:351
+#: spyder_unittest/widgets/unittestgui.py:356
 msgid "Running tests ..."
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:372
+#: spyder_unittest/widgets/unittestgui.py:377
 msgid "Stop"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:373
+#: spyder_unittest/widgets/unittestgui.py:378
 msgid "Stop current test process"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:378
+#: spyder_unittest/widgets/unittestgui.py:383
 msgid "Run tests"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:411
+#: spyder_unittest/widgets/unittestgui.py:416
 msgid "not run"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:418 spyder_unittest/widgets/unittestgui.py:424
+#: spyder_unittest/widgets/unittestgui.py:423 spyder_unittest/widgets/unittestgui.py:429
 msgid "pending"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:425
+#: spyder_unittest/widgets/unittestgui.py:430
 msgid "running"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:431
+#: spyder_unittest/widgets/unittestgui.py:436
 msgid "failure"
 msgstr ""
 
-#: spyder_unittest/widgets/unittestgui.py:432
+#: spyder_unittest/widgets/unittestgui.py:437
 msgid "collection error"
 msgstr ""
-

--- a/spyder_unittest/unittestplugin.py
+++ b/spyder_unittest/unittestplugin.py
@@ -38,8 +38,10 @@ class UnitTestPlugin(SpyderDockablePlugin):
     WIDGET_CLASS = UnitTestWidget
 
     CONF_SECTION = NAME
-    CONF_DEFAULTS = [(CONF_SECTION, {'framework': '', 'wdir': ''})]
-    CONF_NAMEMAP = {CONF_SECTION: [(CONF_SECTION, ['framework', 'wdir'])]}
+    CONF_DEFAULTS = [(CONF_SECTION,
+                      {'framework': '', 'wdir': '', 'coverage': False})]
+    CONF_NAMEMAP = {CONF_SECTION: [(CONF_SECTION,
+                                    ['framework', 'wdir', 'coverage'])]}
     CONF_FILE = True
     CONF_VERSION = '0.1.0'
 
@@ -263,7 +265,8 @@ class UnitTestPlugin(SpyderDockablePlugin):
 
         new_config = Config(
             framework=project.get_option('framework', self.CONF_SECTION),
-            wdir=project.get_option('wdir', self.CONF_SECTION))
+            wdir=project.get_option('wdir', self.CONF_SECTION),
+            coverage=project.get_option('coverage', self.CONF_SECTION))
         if not widget.config_is_valid(new_config):
             new_config = None
         widget.set_config_without_emit(new_config)
@@ -283,6 +286,7 @@ class UnitTestPlugin(SpyderDockablePlugin):
         project.set_option('framework', test_config.framework,
                            self.CONF_SECTION)
         project.set_option('wdir', test_config.wdir, self.CONF_SECTION)
+        project.set_option('coverage', test_config.coverage, self.CONF_SECTION)
 
     def goto_in_editor(self, filename, lineno):
         """

--- a/spyder_unittest/widgets/configdialog.py
+++ b/spyder_unittest/widgets/configdialog.py
@@ -136,7 +136,7 @@ class ConfigDialog(QDialog):
             # FIXME: not sure how to do coverage for unittest, disabled for now
             if (str(self.framework_combobox.currentText()) in ['nose',
                                                               'unittest']
-                    or find_spec_or_loader("pytest-cov") is None):
+                    or find_spec_or_loader("pytest_cov") is None):
                 self.coverage_checkbox.setEnabled(False)
                 self.coverage_checkbox.setChecked(False)
             else:

--- a/spyder_unittest/widgets/configdialog.py
+++ b/spyder_unittest/widgets/configdialog.py
@@ -85,11 +85,12 @@ class ConfigDialog(QDialog):
 
         layout.addSpacing(10)
 
-        coverage_label = _('Include Coverage Report in Output')
-        coverage_toolTip = _('Works for pytest, requires pytest-cov')
+        coverage_label = _('Include coverage report in output')
+        coverage_toolTip = _('Works only for pytest, requires pytest-cov')
         coverage_layout = QHBoxLayout()
         self.coverage_checkbox = QCheckBox(coverage_label, self)
         self.coverage_checkbox.setToolTip(coverage_toolTip)
+        self.coverage_checkbox.setEnabled(False)
         coverage_layout.addWidget(self.coverage_checkbox)
         layout.addLayout(coverage_layout)
 
@@ -116,7 +117,6 @@ class ConfigDialog(QDialog):
 
         self.ok_button = self.buttons.button(QDialogButtonBox.Ok)
         self.ok_button.setEnabled(False)
-        self.coverage_checkbox.setEnabled(False)
         self.framework_combobox.currentIndexChanged.connect(
             self.framework_changed)
 
@@ -133,7 +133,7 @@ class ConfigDialog(QDialog):
         """Called when selected framework changes."""
         if index != -1:
             self.ok_button.setEnabled(True)
-            # FIXME: not sure how to do coverage for unittest, disabled for now
+            # Coverage is only implemented for pytest, and requires pytest_cov
             if (str(self.framework_combobox.currentText()) in ['nose',
                                                               'unittest']
                     or find_spec_or_loader("pytest_cov") is None):

--- a/spyder_unittest/widgets/configdialog.py
+++ b/spyder_unittest/widgets/configdialog.py
@@ -24,6 +24,11 @@ from spyder.py3compat import getcwd, to_text_string
 from spyder.utils import icon_manager as ima
 
 try:
+    from importlib.util import find_spec as find_spec_or_loader
+except ImportError:  # Python 2
+    from pkgutil import find_loader as find_spec_or_loader
+
+try:
     _ = get_translation('spyder_unittest')
 except KeyError:
     import gettext
@@ -81,7 +86,7 @@ class ConfigDialog(QDialog):
         layout.addSpacing(10)
 
         coverage_label = _('Include Coverage Report in Output')
-        coverage_toolTip = _('Works for pytest')
+        coverage_toolTip = _('Works for pytest, requires pytest-cov')
         coverage_layout = QHBoxLayout()
         self.coverage_checkbox = QCheckBox(coverage_label, self)
         self.coverage_checkbox.setToolTip(coverage_toolTip)
@@ -129,8 +134,9 @@ class ConfigDialog(QDialog):
         if index != -1:
             self.ok_button.setEnabled(True)
             # FIXME: not sure how to do coverage for unittest, disabled for now
-            if str(self.framework_combobox.currentText()) in ['nose',
-                                                              'unittest']:
+            if (str(self.framework_combobox.currentText()) in ['nose',
+                                                              'unittest']
+                    or find_spec_or_loader("pytest-cov") is None):
                 self.coverage_checkbox.setEnabled(False)
                 self.coverage_checkbox.setChecked(False)
             else:

--- a/spyder_unittest/widgets/configdialog.py
+++ b/spyder_unittest/widgets/configdialog.py
@@ -81,7 +81,7 @@ class ConfigDialog(QDialog):
         layout.addSpacing(10)
 
         coverage_label = _('Include Coverage Report in Output')
-        coverage_toolTip = _('Works for pytest and nose')
+        coverage_toolTip = _('Works for pytest')
         coverage_layout = QHBoxLayout()
         self.coverage_checkbox = QCheckBox(coverage_label, self)
         self.coverage_checkbox.setToolTip(coverage_toolTip)
@@ -128,8 +128,9 @@ class ConfigDialog(QDialog):
         """Called when selected framework changes."""
         if index != -1:
             self.ok_button.setEnabled(True)
-            # FIXME: not sure how to do coverage for unittest
-            if str(self.framework_combobox.currentText()) == 'unittest':
+            # FIXME: not sure how to do coverage for unittest, disabled for now
+            if str(self.framework_combobox.currentText()) in ['nose',
+                                                              'unittest']:
                 self.coverage_checkbox.setEnabled(False)
                 self.coverage_checkbox.setChecked(False)
             else:

--- a/spyder_unittest/widgets/datatree.py
+++ b/spyder_unittest/widgets/datatree.py
@@ -31,14 +31,16 @@ COLORS = {
     Category.OK: QBrush(QColor("#C1FFBA")),
     Category.FAIL: QBrush(QColor("#FF5050")),
     Category.SKIP: QBrush(QColor("#C5C5C5")),
-    Category.PENDING: QBrush(QColor("#C5C5C5"))
+    Category.PENDING: QBrush(QColor("#C5C5C5")),
+    Category.COVERAGE: QBrush(QColor("#89CFF0"))
 }
 
 COLORS_DARK = {
     Category.OK: QBrush(QColor("#008000")),
     Category.FAIL: QBrush(QColor("#C6001E")),
     Category.SKIP: QBrush(QColor("#505050")),
-    Category.PENDING: QBrush(QColor("#505050"))
+    Category.PENDING: QBrush(QColor("#505050")),
+    Category.COVERAGE: QBrush(QColor("#0047AB"))
 }
 
 STATUS_COLUMN = 0
@@ -415,6 +417,11 @@ class TestDataModel(QAbstractItemModel):
             msg += _(', {} other').format(counts[Category.SKIP])
         if counts[Category.PENDING]:
             msg += _(', {} pending').format(counts[Category.PENDING])
+        if counts[Category.COVERAGE]:
+            # find the coverage result and get its status
+            coverage = [res for res in self.testresults
+                        if res.category == Category.COVERAGE][0].status
+            msg += _(', {} coverage').format(coverage)
         return msg
 
     def emit_summary(self):

--- a/spyder_unittest/widgets/datatree.py
+++ b/spyder_unittest/widgets/datatree.py
@@ -319,6 +319,9 @@ class TestDataModel(QAbstractItemModel):
             elif column == STATUS_COLUMN:
                 return self.testresults[row].status
             elif column == NAME_COLUMN:
+                # don't abbreviate for the code coverage filename
+                if self.testresults[row].category == Category.COVERAGE:
+                    return self.testresults[row].name
                 return self.abbreviator.abbreviate(self.testresults[row].name)
             elif column == MESSAGE_COLUMN:
                 return self.testresults[row].message

--- a/spyder_unittest/widgets/tests/test_configdialog.py
+++ b/spyder_unittest/widgets/tests/test_configdialog.py
@@ -100,9 +100,12 @@ def test_configdialog_clicking_pytest_enables_ok(qtbot):
     assert configdialog.buttons.button(QDialogButtonBox.Ok).isEnabled()
 
 
-def test_configdialog_coverage_checkbox(qtbot):
+def test_configdialog_coverage_checkbox(qtbot, monkeypatch):
     configdialog = ConfigDialog(frameworks, default_config())
     qtbot.addWidget(configdialog)
+    monkeypatch.setattr(
+        'spyder_unittest.widgets.configdialog.find_spec_or_loader',
+        lambda str: "pytest-conv exists")
     configdialog.framework_combobox.setCurrentIndex(1)
     configdialog.coverage_checkbox.click()
     assert configdialog.get_config().coverage is True

--- a/spyder_unittest/widgets/tests/test_configdialog.py
+++ b/spyder_unittest/widgets/tests/test_configdialog.py
@@ -105,10 +105,20 @@ def test_configdialog_coverage_checkbox(qtbot, monkeypatch):
     qtbot.addWidget(configdialog)
     monkeypatch.setattr(
         'spyder_unittest.widgets.configdialog.find_spec_or_loader',
-        lambda str: "pytest-conv exists")
+        lambda s: "pytest-conv exists")
     configdialog.framework_combobox.setCurrentIndex(1)
     configdialog.coverage_checkbox.click()
     assert configdialog.get_config().coverage is True
+
+
+def test_configdialog_coverage_checkbox_pytestcov_noinstall(qtbot, monkeypatch):
+    configdialog = ConfigDialog(frameworks, default_config())
+    qtbot.addWidget(configdialog)
+    monkeypatch.setattr(
+        'spyder_unittest.widgets.configdialog.find_spec_or_loader',
+        lambda s: None)
+    configdialog.framework_combobox.setCurrentIndex(1)
+    assert configdialog.coverage_checkbox.isEnabled() is False
 
 
 def test_configdialog_wdir_lineedit(qtbot):

--- a/spyder_unittest/widgets/tests/test_configdialog.py
+++ b/spyder_unittest/widgets/tests/test_configdialog.py
@@ -43,7 +43,7 @@ frameworks = {r.name: r for r in [SpamRunner, HamRunner, EggsRunner]}
 
 
 def default_config():
-    return Config(framework=None, wdir=os.getcwd())
+    return Config(framework=None, wdir=os.getcwd(), coverage=False)
 
 
 def test_configdialog_uses_frameworks(qtbot):
@@ -98,6 +98,14 @@ def test_configdialog_clicking_pytest_enables_ok(qtbot):
     qtbot.addWidget(configdialog)
     configdialog.framework_combobox.setCurrentIndex(1)
     assert configdialog.buttons.button(QDialogButtonBox.Ok).isEnabled()
+
+
+def test_configdialog_coverage_checkbox(qtbot):
+    configdialog = ConfigDialog(frameworks, default_config())
+    qtbot.addWidget(configdialog)
+    configdialog.framework_combobox.setCurrentIndex(1)
+    configdialog.coverage_checkbox.click()
+    assert configdialog.get_config().coverage is True
 
 
 def test_configdialog_wdir_lineedit(qtbot):

--- a/spyder_unittest/widgets/tests/test_unittestgui.py
+++ b/spyder_unittest/widgets/tests/test_unittestgui.py
@@ -42,14 +42,14 @@ def test_unittestwidget_forwards_sig_edit_goto(qtbot, widget):
     assert blocker.args == ['ham', 42]
 
 def test_unittestwidget_set_config_emits_newconfig(qtbot, widget):
-    config = Config(wdir=os.getcwd(), framework='unittest')
+    config = Config(wdir=os.getcwd(), framework='unittest', coverage=False)
     with qtbot.waitSignal(widget.sig_newconfig) as blocker:
         widget.config = config
     assert blocker.args == [config]
     assert widget.config == config
 
 def test_unittestwidget_set_config_does_not_emit_when_invalid(qtbot, widget):
-    config = Config(wdir=os.getcwd(), framework=None)
+    config = Config(wdir=os.getcwd(), framework=None, coverage=False)
     with qtbot.assertNotEmitted(widget.sig_newconfig):
         widget.config = config
     assert widget.config == config
@@ -57,7 +57,8 @@ def test_unittestwidget_set_config_does_not_emit_when_invalid(qtbot, widget):
 def test_unittestwidget_config_with_unknown_framework_invalid(widget):
     """Check that if the framework in the config is not known,
     config_is_valid() returns False"""
-    config = Config(wdir=os.getcwd(), framework='unknown framework')
+    config = Config(
+        wdir=os.getcwd(), framework='unknown framework', coverage=False)
     assert widget.config_is_valid(config) == False
 
 def test_unittestwidget_process_finished_updates_results(widget):
@@ -117,7 +118,7 @@ def test_unittestwidget_set_message(widget):
 def test_run_tests_starts_testrunner(widget):
     mockRunner = Mock()
     widget.framework_registry.create_runner = Mock(return_value=mockRunner)
-    config = Config(wdir=None, framework='ham')
+    config = Config(wdir=None, framework='ham', coverage=False)
     widget.run_tests(config)
     assert widget.framework_registry.create_runner.call_count == 1
     assert widget.framework_registry.create_runner.call_args[0][0] == 'ham'
@@ -160,7 +161,7 @@ def test_run_tests_and_display_results(qtbot, widget, tmpdir, monkeypatch, frame
     monkeypatch.setattr('spyder_unittest.widgets.unittestgui.QMessageBox',
                         MockQMessageBox)
 
-    config = Config(wdir=tmpdir.strpath, framework=framework)
+    config = Config(wdir=tmpdir.strpath, framework=framework, coverage=False)
     with qtbot.waitSignal(widget.sig_finished, timeout=10000, raising=True):
         widget.run_tests(config)
 
@@ -194,7 +195,7 @@ def test_run_tests_using_unittest_and_display_results(
     monkeypatch.setattr('spyder_unittest.widgets.unittestgui.QMessageBox',
                         MockQMessageBox)
 
-    config = Config(wdir=tmpdir.strpath, framework='unittest')
+    config = Config(wdir=tmpdir.strpath, framework='unittest', coverage=False)
     with qtbot.waitSignal(widget.sig_finished, timeout=10000, raising=True):
         widget.run_tests(config)
 
@@ -220,7 +221,7 @@ def test_run_with_no_tests_discovered_and_display_results(
     monkeypatch.setattr('spyder_unittest.widgets.unittestgui.QMessageBox',
                         MockQMessageBox)
 
-    config = Config(wdir=tmpdir.strpath, framework=framework)
+    config = Config(wdir=tmpdir.strpath, framework=framework, coverage=False)
     with qtbot.waitSignal(widget.sig_finished, timeout=10000, raising=True):
         widget.run_tests(config)
 
@@ -241,7 +242,7 @@ def test_stop_running_tests_before_testresult_is_received(qtbot, widget, tmpdir)
                 "      time.sleep(3)\n"
                 "      self.assertTrue(True)\n")
 
-    config = Config(wdir=tmpdir.strpath, framework='unittest')
+    config = Config(wdir=tmpdir.strpath, framework='unittest', coverage=False)
     widget.run_tests(config)
     qtbot.waitUntil(lambda: widget.testrunner.process.state() == QProcess.Running)
     widget.testrunner.stop_if_running()

--- a/spyder_unittest/widgets/tests/test_unittestgui.py
+++ b/spyder_unittest/widgets/tests/test_unittestgui.py
@@ -14,7 +14,8 @@ from qtpy.QtCore import Qt, QProcess
 import pytest
 
 # Local imports
-from spyder_unittest.backend.runnerbase import Category, TestResult
+from spyder_unittest.backend.runnerbase import (Category, TestResult,
+                                                COV_TEST_NAME)
 from spyder_unittest.widgets.configdialog import Config
 from spyder_unittest.widgets.unittestgui import UnitTestWidget
 
@@ -147,7 +148,10 @@ def test_run_tests_with_pre_test_hook_returning_false(widget):
 
 @pytest.mark.parametrize('results,label',
                          [([TestResult(Category.OK, 'ok', '')], '0 tests failed, 1 passed'),
-                          ([], 'No results to show.')])
+                          ([], 'No results to show.'),
+                          ([TestResult(Category.OK, 'ok', ''),
+                           TestResult(Category.COVERAGE, '90%', COV_TEST_NAME)],
+                          '0 tests failed, 1 passed, 90% coverage')])
 def test_unittestwidget_process_finished_updates_status_label(widget, results, label):
     widget.process_finished(results, 'output')
     assert widget.status_label.text() == '<b>{}</b>'.format(label)

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -341,7 +341,7 @@ class UnitTestWidget(PluginMainWidget):
         self.testrunner.sig_testresult.connect(self.tests_yield_result)
         self.testrunner.sig_stop.connect(self.tests_stopped)
 
-        cov_path = self.get_conf('current_project_path',
+        cov_path = self.get_conf('current_project_path', default='None',
                                  section='project_explorer')
         # config returns 'None' as a string rather than None
         cov_path = config.wdir if cov_path == 'None' else cov_path

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -341,8 +341,13 @@ class UnitTestWidget(PluginMainWidget):
         self.testrunner.sig_testresult.connect(self.tests_yield_result)
         self.testrunner.sig_stop.connect(self.tests_stopped)
 
+        cov_path = self.get_conf('current_project_path',
+                                 section='project_explorer')
+        # config returns 'None' as a string rather than None
+        cov_path = config.wdir if cov_path == 'None' else cov_path
+
         try:
-            self.testrunner.start(config, pythonpath)
+            self.testrunner.start(config, cov_path, pythonpath)
         except RuntimeError:
             QMessageBox.critical(self,
                                  _("Error"), _("Process failed to start"))


### PR DESCRIPTION
Adds some minimal coverage reporting to the verbose output. Currently tested with pytest, and I think it'll work with nose. I don't know how to do this for unittest itself.

It's optional, a checkbox in the config dialog box.

Fixes #33 