### PR TITLE
PR: Display message if pytest exits abnormally

### DIFF
--- a/spyder_unittest/backend/noserunner.py
+++ b/spyder_unittest/backend/noserunner.py
@@ -50,7 +50,7 @@ class NoseRunner(RunnerBase):
         """Called when the unit test process has finished."""
         output = self.read_all_process_output()
         testresults = self.load_data()
-        self.sig_finished.emit(testresults, output)
+        self.sig_finished.emit(testresults, output, True)
 
     def load_data(self):
         """

--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -146,7 +146,7 @@ class PyTestRunner(RunnerBase):
         output = self.read_all_process_output()
         if self.config.coverage:
             self.process_coverage(output)
-        self.sig_finished.emit([], output)
+        self.sig_finished.emit([], output, True)
 
 
 def normalize_module_name(name):

--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -136,17 +136,25 @@ class PyTestRunner(RunnerBase):
                 self.sig_collected.emit([row[1]])
                 self.sig_testresult.emit([file_cov])
 
-    def finished(self):
+    def finished(self, exitcode):
         """
         Called when the unit test process has finished.
 
         This function emits `sig_finished`.
+
+        Parameters
+        ----------
+        exitcode : int
+            Exit code of the test process.
         """
         self.reader.close()
         output = self.read_all_process_output()
         if self.config.coverage:
             self.process_coverage(output)
-        self.sig_finished.emit([], output, True)
+        normal_exit = exitcode in [0, 1, 2, 5]
+        # Meaning of exit codes: 0 = all tests passed, 1 = test failed,
+        # 2 = interrupted, 5 = no tests collected
+        self.sig_finished.emit([], output, normal_exit)
 
 
 def normalize_module_name(name):

--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -146,8 +146,7 @@ class PyTestRunner(RunnerBase):
         output = self.read_all_process_output()
         if self.config.coverage:
             self.process_coverage(output)
-        no_tests_ran = "no tests ran" in output.splitlines()[-1]
-        self.sig_finished.emit([] if no_tests_ran else None, output)
+        self.sig_finished.emit([], output)
 
 
 def normalize_module_name(name):

--- a/spyder_unittest/backend/pytestworker.py
+++ b/spyder_unittest/backend/pytestworker.py
@@ -150,9 +150,11 @@ def main(args):
         writer = FileStub('pytestworker.log')
     else:
         writer = ZmqStreamWriter(int(args[1]))
-    pytest.main(args[2:], plugins=[SpyderPlugin(writer)])
+    result = pytest.main(args[2:], plugins=[SpyderPlugin(writer)])
     writer.close()
+    return result
 
 
 if __name__ == '__main__':
-    main(sys.argv)
+    result = main(sys.argv)
+    sys.exit(result)

--- a/spyder_unittest/backend/runnerbase.py
+++ b/spyder_unittest/backend/runnerbase.py
@@ -99,9 +99,10 @@ class RunnerBase(QObject):
         Emitted just before tests are run.
     sig_testresult(list of TestResult)
         Emitted when tests are finished.
-    sig_finished(list of TestResult, str)
+    sig_finished(list of TestResult, str, bool)
         Emitted when test process finishes. First argument contains the test
-        results, second argument contains the output of the test process.
+        results, second argument contains the output of the test process,
+        third argument is True on normal exit, False on abnormal exit.
     sig_stop()
         Emitted when test process is being stopped.
     """
@@ -110,7 +111,7 @@ class RunnerBase(QObject):
     sig_collecterror = Signal(object)
     sig_starttest = Signal(object)
     sig_testresult = Signal(object)
-    sig_finished = Signal(object, str)
+    sig_finished = Signal(object, str, bool)
     sig_stop = Signal()
 
     def __init__(self, widget, resultfilename=None):

--- a/spyder_unittest/backend/tests/test_pytestrunner.py
+++ b/spyder_unittest/backend/tests/test_pytestrunner.py
@@ -100,11 +100,11 @@ def test_pytestrunner_process_output_with_starttest(qtbot):
     assert blocker.args == [expected]
 
 
-@pytest.mark.parametrize('output,results', [
-    ('== 1 passed in 0.10s ==', None),
-    ('== no tests ran 0.01s ==', [])
+@pytest.mark.parametrize('output', [
+    '== 1 passed in 0.10s ==',
+    '== no tests ran 0.01s =='
 ])
-def test_pytestrunner_finished(qtbot, output, results):
+def test_pytestrunner_finished(qtbot, output):
     mock_reader = Mock()
     mock_reader.close = lambda: None
     runner = PyTestRunner(None)
@@ -113,6 +113,7 @@ def test_pytestrunner_finished(qtbot, output, results):
     runner.config = Config('pytest', None, False)
     with qtbot.waitSignal(runner.sig_finished) as blocker:
         runner.finished()
+    results = []
     assert blocker.args == [results, output]
 
 

--- a/spyder_unittest/backend/tests/test_pytestrunner.py
+++ b/spyder_unittest/backend/tests/test_pytestrunner.py
@@ -114,7 +114,7 @@ def test_pytestrunner_finished(qtbot, output):
     with qtbot.waitSignal(runner.sig_finished) as blocker:
         runner.finished()
     results = []
-    assert blocker.args == [results, output]
+    assert blocker.args == [results, output, True]
 
 
 def standard_logreport_output():

--- a/spyder_unittest/backend/tests/test_pytestrunner.py
+++ b/spyder_unittest/backend/tests/test_pytestrunner.py
@@ -100,11 +100,11 @@ def test_pytestrunner_process_output_with_starttest(qtbot):
     assert blocker.args == [expected]
 
 
-@pytest.mark.parametrize('output', [
-    '== 1 passed in 0.10s ==',
-    '== no tests ran 0.01s =='
-])
-def test_pytestrunner_finished(qtbot, output):
+@pytest.mark.parametrize('exitcode, normal_exit', 
+                         [(0, True), (1, True), (2, True), (3, False),
+                          (4, False), (5, True)])
+def test_pytestrunner_finished(qtbot, exitcode, normal_exit):
+    output = '== 1 passed in 0.10s =='
     mock_reader = Mock()
     mock_reader.close = lambda: None
     runner = PyTestRunner(None)
@@ -112,9 +112,9 @@ def test_pytestrunner_finished(qtbot, output):
     runner.read_all_process_output = lambda: output
     runner.config = Config('pytest', None, False)
     with qtbot.waitSignal(runner.sig_finished) as blocker:
-        runner.finished()
+        runner.finished(exitcode)
     results = []
-    assert blocker.args == [results, output, True]
+    assert blocker.args == [results, output, normal_exit]
 
 
 def standard_logreport_output():

--- a/spyder_unittest/backend/unittestrunner.py
+++ b/spyder_unittest/backend/unittestrunner.py
@@ -39,7 +39,7 @@ class UnittestRunner(RunnerBase):
         """
         output = self.read_all_process_output()
         testresults = self.load_data(output)
-        self.sig_finished.emit(testresults, output)
+        self.sig_finished.emit(testresults, output, True)
 
     def load_data(self, output):
         """

--- a/spyder_unittest/widgets/tests/test_unittestgui.py
+++ b/spyder_unittest/widgets/tests/test_unittestgui.py
@@ -68,12 +68,6 @@ def test_unittestwidget_process_finished_updates_results(widget):
     widget.process_finished(results, 'output')
     assert widget.testdatamodel.testresults == results
 
-def test_unittestwidget_process_finished_with_results_none(widget):
-    results = [TestResult(Category.OK, 'ok', 'hammodule.spam')]
-    widget.testdatamodel.testresults = results
-    widget.process_finished(None, 'output')
-    assert widget.testdatamodel.testresults == results
-
 def test_unittestwidget_replace_pending_with_not_run(widget):
     use_mock_model(widget)
     results = [TestResult(Category.PENDING, 'pending', 'hammodule.eggs'),

--- a/spyder_unittest/widgets/tests/test_unittestgui.py
+++ b/spyder_unittest/widgets/tests/test_unittestgui.py
@@ -65,7 +65,7 @@ def test_unittestwidget_config_with_unknown_framework_invalid(widget):
 
 def test_unittestwidget_process_finished_updates_results(widget):
     results = [TestResult(Category.OK, 'ok', 'hammodule.spam')]
-    widget.process_finished(results, 'output')
+    widget.process_finished(results, 'output', True)
     assert widget.testdatamodel.testresults == results
 
 def test_unittestwidget_replace_pending_with_not_run(widget):
@@ -143,8 +143,13 @@ def test_run_tests_with_pre_test_hook_returning_false(widget):
                            TestResult(Category.COVERAGE, '90%', COV_TEST_NAME)],
                           '0 tests failed, 1 passed, 90% coverage')])
 def test_unittestwidget_process_finished_updates_status_label(widget, results, label):
-    widget.process_finished(results, 'output')
+    widget.process_finished(results, 'output', True)
     assert widget.status_label.text() == '<b>{}</b>'.format(label)
+
+def test_unittestwidget_process_finished_abnormally_status_label(widget):
+    widget.process_finished([], 'output', False)
+    expected_text = '<b>{}</b>'.format('Test process exited abnormally')
+    assert widget.status_label.text() == expected_text
 
 @pytest.mark.parametrize('framework', ['pytest', 'nose'])
 def test_run_tests_and_display_results(qtbot, widget, tmpdir, monkeypatch, framework):

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -374,7 +374,7 @@ class UnitTestWidget(PluginMainWidget):
             button.clicked.connect(
                 lambda checked: self.maybe_configure_and_start())
 
-    def process_finished(self, testresults, output):
+    def process_finished(self, testresults, output, normal_exit):
         """
         Called when unit test process finished.
 
@@ -383,7 +383,11 @@ class UnitTestWidget(PluginMainWidget):
         Parameters
         ----------
         testresults : list of TestResult
+            Test results reported when the test process finished.
         output : str
+            Output from the test process.
+        normal_exit : bool
+            Whether test process exited normally.
         """
         self.output = output
         self.set_running_state(False)
@@ -392,6 +396,8 @@ class UnitTestWidget(PluginMainWidget):
         self.testdatamodel.add_testresults(testresults)
         self.replace_pending_with_not_run()
         self.sig_finished.emit()
+        if not normal_exit:
+            self.set_status_label(_('Test process exited abnormally'))
 
     def replace_pending_with_not_run(self):
         """Change status of pending tests to 'not run''."""

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -382,16 +382,14 @@ class UnitTestWidget(PluginMainWidget):
 
         Parameters
         ----------
-        testresults : list of TestResult or None
-            `None` indicates all test results have already been transmitted.
+        testresults : list of TestResult
         output : str
         """
         self.output = output
         self.set_running_state(False)
         self.testrunner = None
         self.show_log_action.setEnabled(bool(output))
-        if testresults is not None:
-            self.testdatamodel.testresults = testresults
+        self.testdatamodel.add_testresults(testresults)
         self.replace_pending_with_not_run()
         self.sig_finished.emit()
 


### PR DESCRIPTION
This PR checks the exit status of the pytest process and displays a message if it indicates an abnormal exit. This happens when pytest is run with the `--cov` flag to gather coverage information and pytest-cov is not installed.

Fixes #176 