### PR TITLE
PR: Resolve warnings emitted by test suite

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,10 @@
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+#
+# Configuration options for Pytest
+#
+
+[pytest]
+filterwarnings =
+    ignore:.*There already exists a reference.*with id.*under the context:UserWarning

--- a/spyder_unittest/backend/runnerbase.py
+++ b/spyder_unittest/backend/runnerbase.py
@@ -33,6 +33,8 @@ class Category:
 class TestResult:
     """Class representing the result of running a single test."""
 
+    __test__ = False  # this is not a pytest test class
+
     def __init__(self, category, status, name, message='', time=None,
                  extra_text='', filename=None, lineno=None):
         """

--- a/spyder_unittest/widgets/datatree.py
+++ b/spyder_unittest/widgets/datatree.py
@@ -64,6 +64,7 @@ class TestDataView(QTreeView):
     """
 
     sig_edit_goto = Signal(str, int)
+    __test__ = False  # this is not a pytest test class
 
     def __init__(self, parent=None):
         """Constructor."""
@@ -209,6 +210,7 @@ class TestDataModel(QAbstractItemModel):
     """
 
     sig_summary = Signal(str)
+    __test__ = False  # this is not a pytest test class
 
     def __init__(self, parent=None):
         """Constructor."""

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -87,6 +87,7 @@ class UnitTestWidget(PluginMainWidget):
         Arguments are file name and line number (zero-based).
     """
 
+    CONF_SECTION = 'unittest'
     VERSION = '0.0.1'
 
     sig_finished = Signal()


### PR DESCRIPTION
This resolves or explicitly ignores all warnings that appear when running the tests, except for one warning from inside nose which uses the deprecated Python module `imp`. The last warning will be eliminated when we remove support for nose per #178.

Fixes #173 