### PR TITLE
Support changes to `unittest` in Python 3.11

### DIFF
--- a/spyder_unittest/backend/unittestrunner.py
+++ b/spyder_unittest/backend/unittestrunner.py
@@ -7,9 +7,25 @@
 
 # Standard library imports
 import re
+import sys
 
 # Local imports
 from spyder_unittest.backend.runnerbase import Category, RunnerBase, TestResult
+
+
+# Up to Python 3.10, unittest output read:
+# test_fail (testing.test_unittest.MyTest) ... FAIL
+# but from Python 3.11, it reads:
+# test_fail (testing.test_unittest.MyTest.test_fail) ... FAIL
+IS_PY311_OR_GREATER = sys.version_info[:2] >= (3, 11)
+
+
+def _get_fullname(fn_name, cls_name):
+    if IS_PY311_OR_GREATER:
+        function_fullname = cls_name
+    else:
+        function_fullname = '{}.{}'.format(cls_name, fn_name)
+    return function_fullname
 
 
 class UnittestRunner(RunnerBase):
@@ -52,15 +68,14 @@ class UnittestRunner(RunnerBase):
                 data = self.try_parse_result(lines, line_index)
                 if data:
                     line_index = data[0]
-                    if data[3] == 'ok':
+                    if data[2] == 'ok':
                         cat = Category.OK
-                    elif data[3] == 'FAIL' or data[3] == 'ERROR':
+                    elif data[2] == 'FAIL' or data[2] == 'ERROR':
                         cat = Category.FAIL
                     else:
                         cat = Category.SKIP
-                    name = '{}.{}'.format(data[2], data[1])
-                    tr = TestResult(category=cat, status=data[3], name=name,
-                                    message=data[4])
+                    tr = TestResult(category=cat, status=data[2], name=data[1],
+                                    message=data[3])
                     res.append(tr)
                 else:
                     line_index += 1
@@ -73,8 +88,8 @@ class UnittestRunner(RunnerBase):
                     line_index = data[0]
                     test_index = next(
                         i for i, tr in enumerate(res)
-                        if tr.name == '{}.{}'.format(data[2], data[1]))
-                    res[test_index].extra_text = data[3]
+                        if tr.name == data[1])
+                    res[test_index].extra_text = data[2]
                 else:
                     line_index += 1
         except IndexError:
@@ -88,18 +103,17 @@ class UnittestRunner(RunnerBase):
 
         Returns
         -------
-        (int, str, str, str, str) or None
+        (int, str, str, str) or None
             If a test result is parsed successfully then return a tuple with
-            the line index of the first line after the test result, the name
-            of the test function, the name of the test class, the test result,
-            and the reason (if no reason is given, the fourth string is empty).
+            the line index of the first line after the test result, the full
+            name of the test function (including the class), the test result,
+            and the reason (if no reason is given, the third string is empty).
             Otherwise, return None.
         """
         regexp = r'([^\d\W]\w*) \(([^\d\W][\w.]*)\)'
         match = re.match(regexp, lines[line_index])
         if match:
-            function_name = match.group(1)
-            class_name = match.group(2)
+            function_fullname = _get_fullname(match.group(1), match.group(2))
         else:
             return None
         while lines[line_index]:
@@ -109,7 +123,7 @@ class UnittestRunner(RunnerBase):
             if match:
                 result = match.group(1)
                 msg = match.group(3) or ''
-                return (line_index + 1, function_name, class_name, result, msg)
+                return (line_index + 1, function_fullname, result, msg)
             line_index += 1
         return None
 
@@ -119,11 +133,11 @@ class UnittestRunner(RunnerBase):
 
         Returns
         -------
-        (int, str, str, list of str) or None
+        (int, str, list of str) or None
             If an exception block is parsed successfully, then return a tuple
-            with the line index of the first line after the block, the name of
-            the test function, the name of the test class, and the text of the
-            exception. Otherwise, return None.
+            with the line index of the first line after the block, the full
+            name of the test function (including the class), and the text of
+            the exception. Otherwise, return None.
         """
         if not all(char == '=' for char in lines[line_index]):
             return None
@@ -141,4 +155,5 @@ class UnittestRunner(RunnerBase):
         while lines[line_index]:
             exception_text.append(lines[line_index])
             line_index += 1
-        return (line_index, match.group(1), match.group(2), exception_text)
+        function_fullname = _get_fullname(match.group(1), match.group(2))
+        return (line_index, function_fullname, exception_text)


### PR DESCRIPTION
In Python 3.11, the format of `unittest`'s output has changed.  Whereas in Python 3.10 and earlier, the output looks like this (the tests are taken from the test suite in this package):
```
test_fail (testing.test_unittest.MyTest) ... FAIL
test_ok (testing.test_unittest.MyTest) ... ok

======================================================================
FAIL: test_fail (testing.test_unittest.MyTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "<<DIRECTORY>>/testing/test_unittest.py", line 4, in test_fail
    def test_fail(self): self.assertEqual(1+1, 3)
AssertionError: 2 != 3

----------------------------------------------------------------------
Ran 2 tests in 0.000s

FAILED (failures=1)
```
in Python 3.11 (and presumably Python 3.12 and beyond), the test function name is appended to the class name, giving this output:
```
test_fail (testing.test_unittest.MyTest.test_fail) ... FAIL
test_ok (testing.test_unittest.MyTest.test_ok) ... ok

======================================================================
FAIL: test_fail (testing.test_unittest.MyTest.test_fail)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "<<DIRECTORY>>/testing/test_unittest.py", line 4, in test_fail
    def test_fail(self): self.assertEqual(1+1, 3)
                         ^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: 2 != 3

----------------------------------------------------------------------
Ran 2 tests in 0.000s

FAILED (failures=1)

```

This change means that spyder shows output such as `testing.test_unittest.MyTest.test_fail.test_fail` when using this plugin with Python 3.11.  (I know that Spyder does not claim to support 3.11 yet; indeed, debugpy is not at all ready for 3.11, but Debian is testing 3.11, so I'm fixing this issue at this point.)

This PR fixes the issue.  It refactors `spyder_unittest/backend/unittestrunner.py` slightly, by moving the calculation of the test's full name from `load_data` into and new function, `_get_fullname` (whose behaviour depends on the version of Python being used) and calling that from `try_parse_result` and `try_parse_exception_block`.

The unit tests for `unittestrunner.py` also needed to be updated to handle the different behaviours, as well as the refactoring changing the behaviour of `try_parse_result` and `try_parse_exception_block`.

This PR has been tested with both Python 3.10 (old unittest behaviour) and Python 3.11 (new unittest behaviour).