### PR TITLE
Use requested interpreter version when analysing unittest results

### DIFF
--- a/spyder_unittest/backend/runnerbase.py
+++ b/spyder_unittest/backend/runnerbase.py
@@ -7,6 +7,7 @@
 
 # Standard library imports
 import os
+import sys
 import tempfile
 
 # Third party imports
@@ -89,6 +90,9 @@ class RunnerBase(QObject):
         Process running the unit test suite.
     resultfilename : str
         Name of file in which test results are stored.
+    executable : str
+        Path to Python executable used for test.  This is required
+        by the UnittestRunner subclass.
 
     Signals
     -------
@@ -134,6 +138,8 @@ class RunnerBase(QObject):
                                                'unittest.results')
         else:
             self.resultfilename = resultfilename
+        # Set a sensible default
+        self.executable = sys.executable
 
     def create_argument_list(self, config, cov_path):
         """
@@ -189,6 +195,7 @@ class RunnerBase(QObject):
         RuntimeError
             If process failed to start.
         """
+        self.executable = executable
         self.process = self._prepare_process(config, pythonpath)
         p_args = self.create_argument_list(config, cov_path)
         try:

--- a/spyder_unittest/backend/tests/test_unittestrunner.py
+++ b/spyder_unittest/backend/tests/test_unittestrunner.py
@@ -17,6 +17,8 @@ from spyder_unittest.backend.unittestrunner import UnittestRunner
 # test_fail (testing.test_unittest.MyTest) ... FAIL
 # but from Python 3.11, it reads:
 # test_fail (testing.test_unittest.MyTest.test_fail) ... FAIL
+# These tests only test the system executable; they do not test
+# the situation where the requested interpreter is different.
 IS_PY311_OR_GREATER = sys.version_info[:2] >= (3, 11)
 
 
@@ -39,6 +41,7 @@ OK
 """
     output = output11 if IS_PY311_OR_GREATER else output10
     runner = UnittestRunner(None)
+    runner.set_fullname_version()
     res = runner.load_data(output)
     assert len(res) == 2
 
@@ -72,6 +75,7 @@ OK
 """
     output = output11 if IS_PY311_OR_GREATER else output10
     runner = UnittestRunner(None)
+    runner.set_fullname_version()
     res = runner.load_data(output)
     assert len(res) == 1
     assert res[0].category == Category.OK
@@ -115,6 +119,7 @@ FAILED (failures=1)
 """
     output = output11 if IS_PY311_OR_GREATER else output10
     runner = UnittestRunner(None)
+    runner.set_fullname_version()
     res = runner.load_data(output)
     assert len(res) == 2
 
@@ -151,6 +156,7 @@ OK
 """
     output = output11 if IS_PY311_OR_GREATER else output10
     runner = UnittestRunner(None)
+    runner.set_fullname_version()
     res = runner.load_data(output)
     assert len(res) == 2
 
@@ -202,6 +208,7 @@ FAILED (failures=1)
 """
     output = output11 if IS_PY311_OR_GREATER else output10
     runner = UnittestRunner(None)
+    runner.set_fullname_version()
     res = runner.load_data(output)
     assert len(res) == 1
 
@@ -214,6 +221,7 @@ FAILED (failures=1)
 
 def test_try_parse_header_with_ok():
     runner = UnittestRunner(None)
+    runner.set_fullname_version()
     lines10 = ['test_isupper (testfoo.TestStringMethods) ... ok']
     lines11 = ['test_isupper (testfoo.TestStringMethods.test_isupper) ... ok']
     lines = lines11 if IS_PY311_OR_GREATER else lines10
@@ -223,6 +231,7 @@ def test_try_parse_header_with_ok():
 
 def test_try_parse_header_with_xfail():
     runner = UnittestRunner(None)
+    runner.set_fullname_version()
     lines10 = ['test_isupper (testfoo.TestStringMethods) ... expected failure']
     lines11 = ['test_isupper (testfoo.TestStringMethods.test_isupper) ... expected failure']
     lines = lines11 if IS_PY311_OR_GREATER else lines10
@@ -233,6 +242,7 @@ def test_try_parse_header_with_xfail():
 
 def test_try_parse_header_with_message():
     runner = UnittestRunner(None)
+    runner.set_fullname_version()
     lines10 = ["test_nothing (testfoo.Tests) ... skipped 'msg'"]
     lines11 = ["test_nothing (testfoo.Tests.test_nothing) ... skipped 'msg'"]
     lines = lines11 if IS_PY311_OR_GREATER else lines10
@@ -242,6 +252,7 @@ def test_try_parse_header_with_message():
 
 def test_try_parse_header_starting_with_digit():
     runner = UnittestRunner(None)
+    runner.set_fullname_version()
     lines10 = ['0est_isupper (testfoo.TestStringMethods) ... ok']
     lines11 = ['0est_isupper (testfoo.TestStringMethods.0est_isupper) ... ok']
     lines = lines11 if IS_PY311_OR_GREATER else lines10


### PR DESCRIPTION
This is a follow-up to #190 as discussed there; this makes `spyder_unittest` use the version number of the requested Python interpreter rather than the system version.