### PR TITLE
PR: Update codecov coverage upload to use GitHub Action

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -82,14 +82,31 @@ jobs:
           mamba list
       - name: Run tests (Linux)
         if: matrix.OS == 'ubuntu'
-        shell: bash -l {0}
-        run: xvfb-run --auto-servernum pytest spyder_unittest --cov=spyder_unittest --cov-report=xml -vv
-        timeout-minutes: 10
-      - name: Run tests (Mac / Windows)
-        if: matrix.OS != 'ubuntu'
-        shell: bash -l {0}
-        run: pytest spyder_unittest -x -vv
-        timeout-minutes: 10
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          shell: bash
+          command: |
+            . ~/.profile
+            xvfb-run --auto-servernum pytest spyder_unittest --cov=spyder_unittest --cov-report=xml -vv
+      - name: Run tests (MacOS)
+        if: matrix.OS == 'macos'
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          shell: bash
+          command: |
+            . ~/.profile
+            pytest spyder_unittest -x -vv
+      - name: Run tests (Windows)
+        if: matrix.OS == 'windows'
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: pytest spyder_unittest -x -vv
       - name: Upload coverage to Codecov
         if: matrix.OS == 'ubuntu' && matrix.PYTHON_VERSION == '3.10'
         uses: codecov/codecov-action@v3

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Run tests (Linux)
         if: matrix.OS == 'ubuntu'
         shell: bash -l {0}
-        run: xvfb-run --auto-servernum pytest spyder_unittest --cov=spyder_unittest -x -vv
+        run: xvfb-run --auto-servernum pytest spyder_unittest --cov=spyder_unittest --cov-report=xml -vv
         timeout-minutes: 10
       - name: Run tests (Mac / Windows)
         if: matrix.OS != 'ubuntu'
@@ -92,5 +92,7 @@ jobs:
         timeout-minutes: 10
       - name: Upload coverage to Codecov
         if: matrix.OS == 'ubuntu' && matrix.PYTHON_VERSION == '3.10'
-        shell: bash -l {0}
-        run: codecov -t 3458851b-c7a5-4108-be5e-9d19066a2fde
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,4 +1,3 @@
-codecov
 flaky
 nose
 pytest>=5

--- a/spyder_unittest/tests/conftest.py
+++ b/spyder_unittest/tests/conftest.py
@@ -24,7 +24,7 @@ from spyder.config.manager import CONF
 
 
 @pytest.fixture
-def main_window(request):
+def main_window():
     """Main Window fixture"""
 
     # Don't show tours message


### PR DESCRIPTION
Do not install deprecated codecov package and use Codecov GitHub Action instead to upload coverage reports.

Adapted from spyder-ide/spyder#20817.