### PR TITLE
PR: Allow plugin to be run with Spyder 5

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,20 @@ jobs:
       matrix:
         OS: ['ubuntu', 'macos', 'windows']
         PYTHON_VERSION: ['3.8', '3.9', '3.10']
-        SPYDER_SOURCE: ['git']
+        SPYDER_SOURCE: ['conda', 'git']
+        exclude:
+          - OS: 'macos'
+            PYTHON_VERSION: '3.8'
+            SPYDER_SOURCE: 'git'
+          - OS: 'macos'
+            PYTHON_VERSION: '3.9'
+            SPYDER_SOURCE: 'git'
+          - OS: 'windows'
+            PYTHON_VERSION: '3.8'
+            SPYDER_SOURCE: 'git'
+          - OS: 'windows'
+            PYTHON_VERSION: '3.9'
+            SPYDER_SOURCE: 'git'
     name: ${{ matrix.OS }} py${{ matrix.PYTHON_VERSION }} spyder-from-${{ matrix.SPYDER_SOURCE }}
     runs-on: ${{ matrix.OS }}-latest
     env:

--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -1,2 +1,2 @@
 lxml
-spyder>=6.0.0.dev0,<7
+spyder>=5.4.1,<7

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def get_package_data(name, extlist):
 
 
 # Requirements
-REQUIREMENTS = ['lxml', 'spyder>=6.0.0.dev0,<7', 'pyzmq']
+REQUIREMENTS = ['lxml', 'spyder>=5.4.1,<7', 'pyzmq']
 EXTLIST = ['.jpg', '.png', '.json', '.mo', '.ini']
 LIBNAME = 'spyder_unittest'
 

--- a/spyder_unittest/tests/conftest.py
+++ b/spyder_unittest/tests/conftest.py
@@ -20,15 +20,22 @@ from qtpy import QtWebEngineWidgets  # noqa
 
 # Spyder imports
 from spyder import dependencies
+from spyder import version_info as spyder_version_info
 from spyder.api.plugin_registration.registry import PLUGIN_REGISTRY
 from spyder.app import start
 from spyder.config.manager import CONF
 
+SPYDER6 = spyder_version_info[0] == 6
 
 
 @pytest.fixture
-def main_window():
+def main_window(monkeypatch):
     """Main Window fixture"""
+
+    if not SPYDER6:
+        # Disable loading of old third-party plugins in Spyder 5
+        monkeypatch.setattr(
+            'spyder.app.mainwindow.get_spyderplugins_mods', lambda: [])
 
     # Don't show tours message
     CONF.set('tours', 'show_tour_message', False)

--- a/spyder_unittest/tests/test_unittestplugin.py
+++ b/spyder_unittest/tests/test_unittestplugin.py
@@ -15,6 +15,7 @@ import os
 from qtpy.QtCore import Qt
 
 # Spyder imports
+from spyder import version_info as spyder_version_info
 from spyder.api.plugins import Plugins
 from spyder.plugins.mainmenu.api import ApplicationMenus
 
@@ -22,16 +23,22 @@ from spyder.plugins.mainmenu.api import ApplicationMenus
 from spyder_unittest.unittestplugin import UnitTestPlugin
 from spyder_unittest.widgets.configdialog import Config
 
+SPYDER6 = spyder_version_info[0] == 6
+
 
 def test_menu_item(main_window):
     """
     Test that plugin adds item 'Run unit tests' to Run menu.
     """
-    main_menu = main_window.get_plugin(Plugins.MainMenu)
-    run_menu = main_menu.get_application_menu(ApplicationMenus.Run)
+    if SPYDER6:
+        main_menu = main_window.get_plugin(Plugins.MainMenu)
+        run_menu = main_menu.get_application_menu(ApplicationMenus.Run)
+        actions = run_menu.get_actions()
+    else:
+        actions = main_window.run_menu_actions
 
     # Filter out seperators (indicated by action is None) and convert to text
-    menu_items = [action.text() for action in run_menu.get_actions() if action]
+    menu_items = [action.text() for action in actions if action]
 
     assert 'Run unit tests' in menu_items
 
@@ -54,7 +61,7 @@ def test_default_working_dir(main_window, tmpdir):
     """
     Test that plugin's default working dir is current working directory.
     After creating a project, the plugin's default working dir should be the
-    same as the project directory. When the project is closed again, the 
+    same as the project directory. When the project is closed again, the
     plugin's default working dir should revert back to the current working
     directory.
     """
@@ -64,7 +71,10 @@ def test_default_working_dir(main_window, tmpdir):
 
     assert unittest_plugin.get_widget().default_wdir == os.getcwd()
 
-    projects.create_project(project_dir)
+    if SPYDER6:
+        projects.create_project(project_dir)
+    else:
+        projects._create_project(project_dir)
     assert unittest_plugin.get_widget().default_wdir == project_dir
 
     projects.close_project()
@@ -85,8 +95,11 @@ def test_plugin_config(main_window, tmpdir, qtbot):
     assert not config_file_path.check()
     assert unittest_widget.config is None
 
-    # Open project
-    projects.create_project(project_dir)
+    # Create new project
+    if SPYDER6:
+        projects.create_project(project_dir)
+    else:
+        projects._create_project(project_dir)
 
     # Test config file does exist but config is empty
     assert config_file_path.check()
@@ -150,7 +163,7 @@ def test_go_to_test_definition(main_window, tmpdir, qtbot):
     editor = main_window.get_plugin(Plugins.Editor)
     filename = editor.get_current_filename()
     assert filename == testfile_str
-    
+
     # Check that cursor is on line defining `test_fail`
     cursor = editor.get_current_editor().textCursor()
     line = cursor.block().text()


### PR DESCRIPTION
Make plugin compatible with Spyder 5.4.1 and later while keeping compatibility with Spyder 6 as currently in development. In fact, the plugin code already worked with Spyder 5.4.1 so the only changes are in the tests and in lowering the requirements.

Fixes #206