### PR TITLE
PR: Add option to run a single test

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -112,11 +112,11 @@ jobs:
           shell: bash
           command: |
             . ~/.profile
-            pytest spyder_unittest -x -vv
+            pytest spyder_unittest -vv
       - name: Run tests (Windows)
         if: matrix.OS == 'windows'
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 10
           max_attempts: 3
-          command: pytest spyder_unittest -x -vv
+          command: pytest spyder_unittest -vv

--- a/spyder_unittest/backend/abbreviator.py
+++ b/spyder_unittest/backend/abbreviator.py
@@ -5,6 +5,23 @@
 # (see LICENSE.txt for details)
 """Class for abbreviating test names."""
 
+from __future__ import annotations
+
+# Standard imports
+from dataclasses import dataclass
+
+@dataclass
+class Abbreviation:
+    """
+    Abbreviation for one component of a test name.
+
+    Abbreviations are defined recursively, so `.head` is the abbreviation
+    for the first component and `.tail` specifies the abbreviations for the
+    second and later components.
+    """
+    head: str
+    tail: Abbreviator
+
 
 class Abbreviator:
     """
@@ -26,7 +43,7 @@ class Abbreviator:
         the higher-level components as its second element.
     """
 
-    def __init__(self, names=[]):
+    def __init__(self, names: list[str]=[]) -> None:
         """
         Constructor.
 
@@ -35,11 +52,11 @@ class Abbreviator:
         names : list of str
             list of words which needs to be abbreviated.
         """
-        self.dic = {}
+        self.dic: dict[str, Abbreviation] = {}
         for name in names:
             self.add(name)
 
-    def add(self, name):
+    def add(self, name: str) -> None:
         """
         Add name to list of names to be abbreviated.
 
@@ -61,18 +78,18 @@ class Abbreviator:
                        and len_abbrev < len(other)):
                     len_abbrev += 1
                 if len_abbrev == len(start):
-                    self.dic[other][0] = other[:len_abbrev + 1]
+                    self.dic[other].head = other[:len_abbrev + 1]
                 elif len_abbrev == len(other):
-                    self.dic[other][0] = other
+                    self.dic[other].head = other
                     len_abbrev += 1
                 else:
-                    if len(self.dic[other][0]) < len_abbrev:
-                        self.dic[other][0] = other[:len_abbrev]
+                    if len(self.dic[other].head) < len_abbrev:
+                        self.dic[other].head = other[:len_abbrev]
         else:
-            self.dic[start] = [start[:len_abbrev], Abbreviator()]
-        self.dic[start][1].add(rest)
+            self.dic[start] = Abbreviation(start[:len_abbrev], Abbreviator())
+        self.dic[start].tail.add(rest)
 
-    def abbreviate(self, name):
+    def abbreviate(self, name: str) -> str:
         """Return abbreviation of name."""
         if '[' in name:
             name, parameters = name.split('[', 1)
@@ -81,8 +98,8 @@ class Abbreviator:
             parameters = ''
         if '.' in name:
             start, rest = name.split('.', 1)
-            res = (self.dic[start][0]
-                   + '.' + self.dic[start][1].abbreviate(rest))
+            res = (self.dic[start].head
+                   + '.' + self.dic[start].tail.abbreviate(rest))
         else:
             res = name
         return res + parameters

--- a/spyder_unittest/backend/frameworkregistry.py
+++ b/spyder_unittest/backend/frameworkregistry.py
@@ -5,6 +5,16 @@
 # (see LICENSE.txt for details)
 """Keep track of testing frameworks and create test runners when requested."""
 
+from __future__ import annotations
+
+# Standard imports
+from typing import Optional, TYPE_CHECKING
+
+# Local imports
+if TYPE_CHECKING:
+    from spyder_unittest.backend.runnerbase import RunnerBase
+    from spyder_unittest.widgets.unittestgui import UnitTestWidget
+
 
 class FrameworkRegistry():
     """
@@ -24,21 +34,22 @@ class FrameworkRegistry():
         associated runners.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize self."""
-        self.frameworks = {}
+        self.frameworks: dict[str, type[RunnerBase]] = {}
 
-    def register(self, runner_class):
+    def register(self, runner_class: type[RunnerBase]) -> None:
         """Register runner class for a testing framework.
 
         Parameters
         ----------
-        runner_class : type
+        runner_class
             Class used for creating tests runners for the framework.
         """
         self.frameworks[runner_class.name] = runner_class
 
-    def create_runner(self, framework, widget, tempfilename):
+    def create_runner(self, framework: str, widget: UnitTestWidget,
+                      tempfilename: Optional[str]) -> RunnerBase:
         """Create test runner associated to some testing framework.
 
         This creates an instance of the runner class whose `name` attribute
@@ -46,11 +57,11 @@ class FrameworkRegistry():
 
         Parameters
         ----------
-        framework : str
+        framework
             Name of testing framework.
-        widget : UnitTestWidget
+        widget
             Unit test widget which constructs the test runner.
-        resultfilename : str or None
+        resultfilename
             Name of file in which to store test results. If None, use default.
 
         Returns

--- a/spyder_unittest/backend/nose2runner.py
+++ b/spyder_unittest/backend/nose2runner.py
@@ -5,12 +5,19 @@
 # (see LICENSE.txt for details)
 """Support for Nose framework."""
 
+from __future__ import annotations
+
+# Standard library imports
+from typing import Optional, TYPE_CHECKING
+
 # Third party imports
 from lxml import etree
 from spyder.config.base import get_translation
 
 # Local imports
 from spyder_unittest.backend.runnerbase import Category, RunnerBase, TestResult
+if TYPE_CHECKING:
+    from spyder_unittest.widgets.configdialog import Config
 
 try:
     _ = get_translation('spyder_unittest')
@@ -25,7 +32,8 @@ class Nose2Runner(RunnerBase):
     module = 'nose2'
     name = 'nose2'
 
-    def create_argument_list(self, config, cov_path):
+    def create_argument_list(self, config: Config,
+                             cov_path: Optional[str]) -> list[str]:
         """Create argument list for testing process."""
         arguments = [
             '-m', self.module, '--plugin=nose2.plugins.junitxml',
@@ -34,13 +42,13 @@ class Nose2Runner(RunnerBase):
         arguments += config.args
         return arguments
 
-    def finished(self):
+    def finished(self, exitcode: int) -> None:
         """Called when the unit test process has finished."""
         output = self.read_all_process_output()
         testresults = self.load_data()
         self.sig_finished.emit(testresults, output, True)
 
-    def load_data(self):
+    def load_data(self) -> list[TestResult]:
         """
         Read and parse unit test results.
 
@@ -56,7 +64,7 @@ class Nose2Runner(RunnerBase):
         try:
             data = etree.parse(self.resultfilename).getroot()
         except OSError:
-            data = []
+            return []
 
         testresults = []
         for testcase in data:

--- a/spyder_unittest/backend/nose2runner.py
+++ b/spyder_unittest/backend/nose2runner.py
@@ -40,6 +40,8 @@ class Nose2Runner(RunnerBase):
             '-m', self.module, '--plugin=nose2.plugins.junitxml',
             '--junit-xml', '--junit-xml-path={}'.format(self.resultfilename)
         ]
+        if single_test:
+            arguments.append(single_test)
         arguments += config.args
         return arguments
 

--- a/spyder_unittest/backend/nose2runner.py
+++ b/spyder_unittest/backend/nose2runner.py
@@ -33,7 +33,8 @@ class Nose2Runner(RunnerBase):
     name = 'nose2'
 
     def create_argument_list(self, config: Config,
-                             cov_path: Optional[str]) -> list[str]:
+                             cov_path: Optional[str],
+                             single_test: Optional[str]) -> list[str]:
         """Create argument list for testing process."""
         arguments = [
             '-m', self.module, '--plugin=nose2.plugins.junitxml',

--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -35,7 +35,8 @@ class PyTestRunner(RunnerBase):
     name = 'pytest'
 
     def create_argument_list(self, config: Config,
-                             cov_path: Optional[str]) -> list[str]:
+                             cov_path: Optional[str],
+                             single_test: Optional[str]) -> list[str]:
         """Create argument list for testing process."""
         dirname = os.path.dirname(__file__)
         pyfile = os.path.join(dirname, 'workers', 'pytestworker.py')
@@ -46,12 +47,13 @@ class PyTestRunner(RunnerBase):
         return arguments
 
     def start(self, config: Config, cov_path: Optional[str],
-              executable: str, pythonpath: list[str]) -> None:
+              executable: str, pythonpath: list[str],
+              single_test: Optional[str]) -> None:
         """Start process which will run the unit test suite."""
         self.config = config
         self.reader = ZmqStreamReader()
         self.reader.sig_received.connect(self.process_output)
-        RunnerBase.start(self, config, cov_path, executable, pythonpath)
+        super().start(config, cov_path, executable, pythonpath, single_test)
 
     def process_output(self, output: list[dict[str, Any]]) -> None:
         """

--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -43,6 +43,8 @@ class PyTestRunner(RunnerBase):
         arguments = [pyfile, str(self.reader.port)]
         if config.coverage:
             arguments += [f'--cov={cov_path}', '--cov-report=term-missing']
+        if single_test:
+            arguments.append(self.convert_testname_to_nodeid(single_test))
         arguments += config.args
         return arguments
 
@@ -178,6 +180,20 @@ class PyTestRunner(RunnerBase):
         module, name = nodeid.split('::', 1)
         module = self.normalize_module_name(module)
         return '{}.{}'.format(module, name)
+
+    def convert_testname_to_nodeid(self, testname: str) -> str:
+        """
+        Convert a test name to a nodeid relative to wdir.
+
+        A true nodeid is relative to the pytest root dir. The return value of
+        this function is like a nodeid but relative to the wdir (i.e., the
+        directory from which test are run). This is the format that pytest
+        expects when running single tests.
+        """
+        *path_parts, last_part = testname.split('.')
+        path_parts[-1] += '.py'
+        nodeid = '/'.join(path_parts) + '::' + last_part
+        return nodeid
 
     def logreport_collecterror_to_tuple(
             self, report: dict[str, Any]) -> tuple[str, str]:

--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -154,7 +154,19 @@ class PyTestRunner(RunnerBase):
 
         This function strips the .py suffix and replaces '/' by '.', so that
         'ham/spam.py' becomes 'ham.spam'.
+
+        The result is relative to the directory from which tests are run and
+        not the pytest root dir.
         """
+        wdir = osp.realpath(self.config.wdir)
+        if wdir != self.rootdir:
+            abspath = osp.join(self.rootdir, name)
+            try:
+                name = osp.relpath(abspath, start=wdir)
+            except ValueError:
+                # Happens on Windows if paths are on different drives
+                pass
+
         if name.endswith('.py'):
             name = name[:-3]
         return name.replace('/', '.')

--- a/spyder_unittest/backend/pytestrunner.py
+++ b/spyder_unittest/backend/pytestrunner.py
@@ -173,7 +173,7 @@ class PyTestRunner(RunnerBase):
 
         if name.endswith('.py'):
             name = name[:-3]
-        return name.replace('/', '.')
+        return name.replace(osp.sep, '.')
 
     def convert_nodeid_to_testname(self, nodeid: str) -> str:
         """Convert a nodeid to a test name."""
@@ -192,7 +192,7 @@ class PyTestRunner(RunnerBase):
         """
         *path_parts, last_part = testname.split('.')
         path_parts[-1] += '.py'
-        nodeid = '/'.join(path_parts) + '::' + last_part
+        nodeid = osp.join(*path_parts) + '::' + last_part
         return nodeid
 
     def logreport_collecterror_to_tuple(

--- a/spyder_unittest/backend/runnerbase.py
+++ b/spyder_unittest/backend/runnerbase.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 # Standard library imports
 from enum import IntEnum
+import logging
 import os
 import tempfile
 from typing import ClassVar, Optional, TYPE_CHECKING
@@ -22,6 +23,9 @@ if TYPE_CHECKING:
     from spyder_unittest.widgets.configdialog import Config
     from spyder_unittest.widgets.unittestgui import UnitTestWidget
 
+
+# Logging
+logger = logging.getLogger(__name__)
 
 # if generating coverage report, use this name for the TestResult
 # it's here in case we can get coverage results from unittest too
@@ -208,6 +212,7 @@ class RunnerBase(QObject):
             os.remove(self.resultfilename)
         except OSError:
             pass
+        logger.debug(f'Starting Python process with arguments {p_args}')
         self.process.start(executable, p_args)
         running = self.process.waitForStarted()
         if not running:

--- a/spyder_unittest/backend/runnerbase.py
+++ b/spyder_unittest/backend/runnerbase.py
@@ -7,11 +7,9 @@
 
 # Standard library imports
 import os
-import sys
 import tempfile
 
 # Third party imports
-from importlib.util import find_spec as find_spec_or_loader
 from qtpy.QtCore import (QObject, QProcess, QProcessEnvironment, QTextCodec,
                          Signal)
 

--- a/spyder_unittest/backend/runnerbase.py
+++ b/spyder_unittest/backend/runnerbase.py
@@ -75,7 +75,7 @@ class RunnerBase(QObject):
     Base class for running tests with a framework that uses JUnit XML.
 
     This is an abstract class, meant to be subclassed before being used.
-    Concrete subclasses should define executable and create_argument_list(),
+    Concrete subclasses should define create_argument_list() and finished().
 
     All communication back to the caller is done via signals.
 
@@ -90,9 +90,6 @@ class RunnerBase(QObject):
         Process running the unit test suite.
     resultfilename : str
         Name of file in which test results are stored.
-    executable : str
-        Path to Python executable used for test.  This is required
-        by the UnittestRunner subclass.
 
     Signals
     -------
@@ -138,8 +135,6 @@ class RunnerBase(QObject):
                                                'unittest.results')
         else:
             self.resultfilename = resultfilename
-        # Set a sensible default
-        self.executable = sys.executable
 
     def create_argument_list(self, config, cov_path):
         """
@@ -195,7 +190,6 @@ class RunnerBase(QObject):
         RuntimeError
             If process failed to start.
         """
-        self.executable = executable
         self.process = self._prepare_process(config, pythonpath)
         p_args = self.create_argument_list(config, cov_path)
         try:

--- a/spyder_unittest/backend/runnerbase.py
+++ b/spyder_unittest/backend/runnerbase.py
@@ -141,7 +141,8 @@ class RunnerBase(QObject):
             self.resultfilename = resultfilename
 
     def create_argument_list(self, config: Config,
-                             cov_path: Optional[str]) -> list[str]:
+                             cov_path: Optional[str],
+                             single_test: Optional[str]) -> list[str]:
         """
         Create argument list for testing process (dummy).
 
@@ -171,7 +172,8 @@ class RunnerBase(QObject):
         return process
 
     def start(self, config: Config, cov_path: Optional[str],
-              executable: str, pythonpath: list[str]) -> None:
+              executable: str, pythonpath: list[str],
+              single_test: Optional[str]) -> None:
         """
         Start process which will run the unit test suite.
 
@@ -183,14 +185,17 @@ class RunnerBase(QObject):
 
         Parameters
         ----------
-        config : Config
+        config
             Unit test configuration.
-        cov_path : str or None
+        cov_path
             Path to filter source for coverage report
-        executable : str
+        executable
             Path to Python executable
-        pythonpath : list of str
+        pythonpath
             List of directories to be added to the Python path
+        single_test
+            If None, run all tests; otherwise, it is the name of the only test
+            to be run.
 
         Raises
         ------
@@ -198,7 +203,7 @@ class RunnerBase(QObject):
             If process failed to start.
         """
         self.process = self._prepare_process(config, pythonpath)
-        p_args = self.create_argument_list(config, cov_path)
+        p_args = self.create_argument_list(config, cov_path, single_test)
         try:
             os.remove(self.resultfilename)
         except OSError:

--- a/spyder_unittest/backend/tests/test_pytestrunner.py
+++ b/spyder_unittest/backend/tests/test_pytestrunner.py
@@ -137,6 +137,20 @@ def test_normalize_module_name(runner, wdir, expected):
         assert result == expected
 
 
+def test_convert_nodeid_to_testname(runner):
+    nodeid = 'spam/eggs.py::test_foo'
+    testname = 'spam.eggs.test_foo'
+    result = runner.convert_nodeid_to_testname(nodeid)
+    assert result == testname
+
+
+def test_convert_testname_to_nodeid(runner):
+    nodeid = 'spam/eggs.py::test_foo'
+    testname = 'spam.eggs.test_foo'
+    result = runner.convert_testname_to_nodeid(testname)
+    assert result == nodeid
+
+
 def standard_logreport_output():
     return {
         'event': 'logreport',

--- a/spyder_unittest/backend/tests/test_pytestrunner.py
+++ b/spyder_unittest/backend/tests/test_pytestrunner.py
@@ -14,8 +14,7 @@ from unittest.mock import Mock
 import pytest
 
 # Local imports
-from spyder_unittest.backend.pytestrunner import (PyTestRunner,
-                                                  logreport_to_testresult)
+from spyder_unittest.backend.pytestrunner import PyTestRunner
 from spyder_unittest.backend.runnerbase import (Category, TestResult,
                                                 COV_TEST_NAME)
 from spyder_unittest.widgets.configdialog import Config
@@ -232,7 +231,9 @@ def test_logreport_to_testresult_with_outcome_and_possible_error(outcome,
     report['witherror'] = witherror
     expected = TestResult(category, outcome, 'foo.bar', time=42,
                           filename=osp.join('ham', 'foo.py'), lineno=24)
-    assert logreport_to_testresult(report, 'ham') == expected
+    runner = PyTestRunner(None)
+    runner.rootdir = 'ham'
+    assert runner.logreport_to_testresult(report) == expected
 
 
 def test_logreport_to_testresult_with_message():
@@ -241,7 +242,9 @@ def test_logreport_to_testresult_with_message():
     expected = TestResult(Category.OK, 'passed', 'foo.bar', message='msg',
                           time=42, filename=osp.join('ham', 'foo.py'),
                           lineno=24)
-    assert logreport_to_testresult(report, 'ham') == expected
+    runner = PyTestRunner(None)
+    runner.rootdir = 'ham'
+    assert runner.logreport_to_testresult(report) == expected
 
 
 def test_logreport_to_testresult_with_extratext():
@@ -250,7 +253,9 @@ def test_logreport_to_testresult_with_extratext():
     expected = TestResult(Category.OK, 'passed', 'foo.bar', time=42,
                           extra_text='long msg',
                           filename=osp.join('ham', 'foo.py'), lineno=24)
-    assert logreport_to_testresult(report, 'ham') == expected
+    runner = PyTestRunner(None)
+    runner.rootdir = 'ham'
+    assert runner.logreport_to_testresult(report) == expected
 
 
 @pytest.mark.parametrize('longrepr,prefix', [
@@ -268,5 +273,6 @@ def test_logreport_to_testresult_with_output(longrepr, prefix):
     expected = TestResult(Category.OK, 'passed', 'foo.bar', time=42,
                           extra_text=txt, filename=osp.join('ham', 'foo.py'),
                           lineno=24)
-    assert logreport_to_testresult(report, 'ham') == expected
-
+    runner = PyTestRunner(None)
+    runner.rootdir = 'ham'
+    assert runner.logreport_to_testresult(report) == expected

--- a/spyder_unittest/backend/tests/test_pytestrunner.py
+++ b/spyder_unittest/backend/tests/test_pytestrunner.py
@@ -41,7 +41,7 @@ def test_pytestrunner_create_argument_list(monkeypatch, runner):
     runner.reader = mock_reader
     monkeypatch.setattr('spyder_unittest.backend.pytestrunner.os.path.dirname',
                         lambda _: 'dir')
-    arg_list = runner.create_argument_list(config, cov_path)
+    arg_list = runner.create_argument_list(config, cov_path, None)
     pyfile, port, *coverage, last = arg_list
     assert pyfile == osp.join('dir', 'workers', 'pytestworker.py')
     assert port == '42'
@@ -55,20 +55,20 @@ def test_pytestrunner_start(monkeypatch):
         MockZMQStreamReader)
     mock_reader = MockZMQStreamReader()
 
-    MockRunnerBase = Mock(name='RunnerBase')
-    monkeypatch.setattr('spyder_unittest.backend.pytestrunner.RunnerBase',
-                        MockRunnerBase)
+    mock_base_start = Mock()
+    monkeypatch.setattr('spyder_unittest.backend.unittestrunner.RunnerBase.start',
+                        mock_base_start)
 
     runner = PyTestRunner(None, 'results')
     config = Config()
     cov_path = None
-    runner.start(config, cov_path, sys.executable, ['pythondir'])
+    runner.start(config, cov_path, sys.executable, ['pythondir'], None)
     assert runner.config is config
     assert runner.reader is mock_reader
     runner.reader.sig_received.connect.assert_called_once_with(
         runner.process_output)
-    MockRunnerBase.start.assert_called_once_with(
-        runner, config, cov_path, sys.executable, ['pythondir'])
+    mock_base_start.assert_called_once_with(
+        config, cov_path, sys.executable, ['pythondir'], None)
 
 
 def test_pytestrunner_process_output_with_collected(qtbot, runner):

--- a/spyder_unittest/backend/tests/test_pytestrunner.py
+++ b/spyder_unittest/backend/tests/test_pytestrunner.py
@@ -120,8 +120,8 @@ def test_pytestrunner_finished(qtbot, exitcode, normal_exit):
 
 @pytest.mark.parametrize('wdir, expected', [
     ('ham', 'spam.eggs'),
-    ('ham/spam', 'eggs'),
-    ('link-to-ham/spam', 'eggs')])
+    (osp.join('ham', 'spam'), 'eggs'),
+    (osp.join('link-to-ham', 'spam'), 'eggs')])
 def test_normalize_module_name(runner, wdir, expected):
     def new_realpath(name):
         """Simulate link from `link-to-ham` to `ham`"""
@@ -133,19 +133,19 @@ def test_normalize_module_name(runner, wdir, expected):
     with patch('spyder_unittest.backend.pytestrunner.osp.realpath',
                side_effect=new_realpath):
         runner.config = Config(wdir=wdir)
-        result = runner.normalize_module_name('spam/eggs.py')
+        result = runner.normalize_module_name(osp.join('spam', 'eggs.py'))
         assert result == expected
 
 
 def test_convert_nodeid_to_testname(runner):
-    nodeid = 'spam/eggs.py::test_foo'
+    nodeid = osp.join('spam', 'eggs.py') + '::test_foo'
     testname = 'spam.eggs.test_foo'
     result = runner.convert_nodeid_to_testname(nodeid)
     assert result == testname
 
 
 def test_convert_testname_to_nodeid(runner):
-    nodeid = 'spam/eggs.py::test_foo'
+    nodeid = osp.join('spam', 'eggs.py') + '::test_foo'
     testname = 'spam.eggs.test_foo'
     result = runner.convert_testname_to_nodeid(testname)
     assert result == nodeid

--- a/spyder_unittest/backend/tests/test_runnerbase.py
+++ b/spyder_unittest/backend/tests/test_runnerbase.py
@@ -28,7 +28,7 @@ def test_runnerbase_with_nonexisting_module():
         foo_runner.create_argument_list(config, 'cov_path')
 
     with pytest.raises(NotImplementedError):
-        foo_runner.finished()
+        foo_runner.finished(0)
 
 
 @pytest.mark.parametrize('pythonpath,env_pythonpath', [

--- a/spyder_unittest/backend/tests/test_runnerbase.py
+++ b/spyder_unittest/backend/tests/test_runnerbase.py
@@ -25,7 +25,7 @@ def test_runnerbase_with_nonexisting_module():
     config = Config(foo_runner.module, 'wdir', True)
 
     with pytest.raises(NotImplementedError):
-        foo_runner.create_argument_list(config, 'cov_path')
+        foo_runner.create_argument_list(config, 'cov_path', None)
 
     with pytest.raises(NotImplementedError):
         foo_runner.finished(0)
@@ -81,12 +81,12 @@ def test_runnerbase_start(monkeypatch):
 
     runner = RunnerBase(None, 'results')
     runner._prepare_process = lambda c, p: mock_process
-    runner.create_argument_list = lambda c, cp: ['arg1', 'arg2']
+    runner.create_argument_list = lambda c, cp, st: ['arg1', 'arg2']
     config = Config('pytest', 'wdir', False)
     cov_path = None
     mock_process.waitForStarted = lambda: False
     with pytest.raises(RuntimeError):
-        runner.start(config, cov_path, 'python_exec', ['pythondir'])
+        runner.start(config, cov_path, 'python_exec', ['pythondir'], None)
 
     mock_process.start.assert_called_once_with('python_exec', ['arg1', 'arg2'])
     mock_remove.assert_called_once_with('results')

--- a/spyder_unittest/backend/tests/test_unittestrunner.py
+++ b/spyder_unittest/backend/tests/test_unittestrunner.py
@@ -34,7 +34,7 @@ def test_unittestrunner_create_argument_list(monkeypatch):
         'spyder_unittest.backend.unittestrunner.osp.dirname',
         lambda _: 'dir')
 
-    result = runner.create_argument_list(config, cov_path)
+    result = runner.create_argument_list(config, cov_path, None)
 
     pyfile = osp.join('dir', 'workers', 'unittestworker.py')
     assert result == [pyfile, '42', '--extra-arg']
@@ -58,14 +58,14 @@ def test_unittestrunner_start(monkeypatch):
     config = Config()
     cov_path = None
 
-    runner.start(config, cov_path, sys.executable, ['pythondir'])
+    runner.start(config, cov_path, sys.executable, ['pythondir'], None)
 
     assert runner.config is config
     assert runner.reader is mock_reader
     runner.reader.sig_received.connect.assert_called_once_with(
         runner.process_output)
     mock_base_start.assert_called_once_with(
-        config, cov_path, sys.executable, ['pythondir'])
+        config, cov_path, sys.executable, ['pythondir'], None)
 
 
 def test_unittestrunner_process_output_with_collected(qtbot):

--- a/spyder_unittest/backend/unittestrunner.py
+++ b/spyder_unittest/backend/unittestrunner.py
@@ -30,6 +30,8 @@ class UnittestRunner(RunnerBase):
         dirname = osp.dirname(__file__)
         pyfile = osp.join(dirname, 'workers', 'unittestworker.py')
         arguments = [pyfile, str(self.reader.port)]
+        if single_test:
+            arguments.append(single_test)
         arguments += config.args
         return arguments
 

--- a/spyder_unittest/backend/unittestrunner.py
+++ b/spyder_unittest/backend/unittestrunner.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 # Standard library imports
 import os.path as osp
+from typing import Any, Optional
 
 # Local imports
 from spyder_unittest.widgets.configdialog import Config
@@ -22,7 +23,8 @@ class UnittestRunner(RunnerBase):
     module = 'unittest'
     name = 'unittest'
 
-    def create_argument_list(self, config: Config, cov_path: str) -> list[str]:
+    def create_argument_list(self, config: Config,
+                             cov_path: Optional[str]) -> list[str]:
         """Create argument list for testing process."""
         dirname = osp.dirname(__file__)
         pyfile = osp.join(dirname, 'workers', 'unittestworker.py')
@@ -30,15 +32,15 @@ class UnittestRunner(RunnerBase):
         arguments += config.args
         return arguments
 
-    def start(self, config: Config, cov_path: str, executable: str,
-              pythonpath: str) -> None:
+    def start(self, config: Config, cov_path: Optional[str],
+              executable: str, pythonpath: list[str]) -> None:
         """Start process which will run the unit test suite."""
         self.config = config
         self.reader = ZmqStreamReader()
         self.reader.sig_received.connect(self.process_output)
         super().start(config, cov_path, executable, pythonpath)
 
-    def finished(self) -> None:
+    def finished(self, exitcode: int) -> None:
         """
         Called when the unit test process has finished.
 
@@ -48,7 +50,7 @@ class UnittestRunner(RunnerBase):
         output = self.read_all_process_output()
         self.sig_finished.emit([], output, True)
 
-    def process_output(self, output: list[dict]) -> None:
+    def process_output(self, output: list[dict[str, Any]]) -> None:
         """
         Process output of test process.
 
@@ -78,7 +80,7 @@ class UnittestRunner(RunnerBase):
             self.sig_testresult.emit(result_list)
 
 
-def add_event_to_testresult(event: dict) -> TestResult:
+def add_event_to_testresult(event: dict[str, Any]) -> TestResult:
     """Convert an addXXX event sent by test process to a TestResult."""
     status = event['event'][3].lower() + event['event'][4:]
     if status in ('error', 'failure', 'unexpectedSuccess'):

--- a/spyder_unittest/backend/unittestrunner.py
+++ b/spyder_unittest/backend/unittestrunner.py
@@ -24,7 +24,8 @@ class UnittestRunner(RunnerBase):
     name = 'unittest'
 
     def create_argument_list(self, config: Config,
-                             cov_path: Optional[str]) -> list[str]:
+                             cov_path: Optional[str],
+                             single_test: Optional[str]) -> list[str]:
         """Create argument list for testing process."""
         dirname = osp.dirname(__file__)
         pyfile = osp.join(dirname, 'workers', 'unittestworker.py')
@@ -33,12 +34,13 @@ class UnittestRunner(RunnerBase):
         return arguments
 
     def start(self, config: Config, cov_path: Optional[str],
-              executable: str, pythonpath: list[str]) -> None:
+              executable: str, pythonpath: list[str],
+              single_test: Optional[str]) -> None:
         """Start process which will run the unit test suite."""
         self.config = config
         self.reader = ZmqStreamReader()
         self.reader.sig_received.connect(self.process_output)
-        super().start(config, cov_path, executable, pythonpath)
+        super().start(config, cov_path, executable, pythonpath, single_test)
 
     def finished(self, exitcode: int) -> None:
         """

--- a/spyder_unittest/backend/zmqreader.py
+++ b/spyder_unittest/backend/zmqreader.py
@@ -36,7 +36,7 @@ class ZmqStreamReader(QObject):
 
     sig_received = Signal(object)
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Constructor; also constructs ZMQ stream."""
         super().__init__()
         self.context = zmq.Context()
@@ -46,7 +46,7 @@ class ZmqStreamReader(QObject):
         self.notifier = QSocketNotifier(fid, QSocketNotifier.Read, self)
         self.notifier.activated.connect(self.received_message)
 
-    def received_message(self):
+    def received_message(self) -> None:
         """Called when a message is received."""
         self.notifier.setEnabled(False)
         messages = []
@@ -61,7 +61,7 @@ class ZmqStreamReader(QObject):
         if messages:
             self.sig_received.emit(messages)
 
-    def close(self):
+    def close(self) -> None:
         """Read any remaining messages and close stream."""
         self.received_message()  # Flush remaining messages
         self.notifier.setEnabled(False)

--- a/spyder_unittest/unittestplugin.py
+++ b/spyder_unittest/unittestplugin.py
@@ -18,7 +18,6 @@ from spyder.api.plugins import Plugins, SpyderDockablePlugin
 from spyder.api.plugin_registration.decorators import (
     on_plugin_available, on_plugin_teardown)
 from spyder.config.base import get_translation
-from spyder.config.gui import is_dark_interface
 from spyder.plugins.mainmenu.api import ApplicationMenus
 from spyder.utils.palette import SpyderPalette
 
@@ -166,7 +165,6 @@ class UnitTestPlugin(SpyderDockablePlugin):
         """
         preferences = self.get_plugin(Plugins.Preferences)
         preferences.register_plugin_preferences(self)
-        self.get_widget().use_dark_interface(is_dark_interface())
 
     @on_plugin_teardown(plugin=Plugins.Preferences)
     def on_preferences_teardown(self):

--- a/spyder_unittest/widgets/datatree.py
+++ b/spyder_unittest/widgets/datatree.py
@@ -192,11 +192,6 @@ class TestDataModel(QAbstractItemModel, SpyderConfigurationAccessor):
     a tuple (row, column, id). The id is TOPLEVEL_ID for top-level items.
     For level-2 items, the id is the index of the test in `self.testresults`.
 
-    Attributes
-    ----------
-    is_dark_interface : bool
-        Whether to use colours appropriate for a dark user interface.
-
     Signals
     -------
     sig_summary(str)
@@ -212,7 +207,6 @@ class TestDataModel(QAbstractItemModel, SpyderConfigurationAccessor):
         """Constructor."""
         QAbstractItemModel.__init__(self, parent)
         self.abbreviator = Abbreviator()
-        self.is_dark_interface = False
         self.testresults = []
         try:
             self.monospace_font = parent.window().editor.get_plugin_font()

--- a/spyder_unittest/widgets/tests/test_datatree.py
+++ b/spyder_unittest/widgets/tests/test_datatree.py
@@ -67,6 +67,12 @@ def test_go_to_test_definition_with_lineno_none(view_and_model, qtbot):
         view.go_to_test_definition(model.index(1, 0))
     assert blocker.args == ['ham.py', 0]
 
+def test_run_single_test(view_and_model, qtbot):
+    view, model = view_and_model
+    with qtbot.waitSignal(view.sig_single_test_run_requested) as blocker:
+        view.run_single_test(model.index(1, 0))
+    assert blocker.args == ['foo.bar']
+
 def test_make_index_canonical_with_index_in_column2(view_and_model):
     view, model = view_and_model
     index = model.index(1, 2)
@@ -88,20 +94,33 @@ def test_make_index_canonical_with_invalid_index(view_and_model):
 def test_build_context_menu(view_and_model):
     view, model = view_and_model
     menu = view.build_context_menu(model.index(0, 0))
+    assert len(menu.actions()) == 3
     assert menu.actions()[0].text() == 'Expand'
     assert menu.actions()[1].text() == 'Go to definition'
+    assert menu.actions()[2].text() == 'Run only this test'
 
 def test_build_context_menu_with_disabled_entries(view_and_model):
     view, model = view_and_model
     menu = view.build_context_menu(model.index(0, 0))
     assert menu.actions()[0].isEnabled() == False
     assert menu.actions()[1].isEnabled() == False
+    assert menu.actions()[2].isEnabled() == True
 
 def test_build_context_menu_with_enabled_entries(view_and_model):
     view, model = view_and_model
     menu = view.build_context_menu(model.index(1, 0))
     assert menu.actions()[0].isEnabled() == True
     assert menu.actions()[1].isEnabled() == True
+    assert menu.actions()[2].isEnabled() == True
+
+def test_build_context_menu_with_coverage_entry(view_and_model):
+    view, model = view_and_model
+    testresult = TestResult(Category.COVERAGE, 'coverage', 'foo')
+    model.testresults.append(testresult)
+    menu = view.build_context_menu(model.index(2, 0))
+    assert menu.actions()[0].isEnabled() == False
+    assert menu.actions()[1].isEnabled() == False
+    assert menu.actions()[2].isEnabled() == False
 
 def test_build_context_menu_with_expanded_entry(view_and_model):
     view, model = view_and_model

--- a/spyder_unittest/widgets/tests/test_unittestgui.py
+++ b/spyder_unittest/widgets/tests/test_unittestgui.py
@@ -8,7 +8,7 @@
 # Standard library imports
 import os
 import sys
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 # Third party imports
 from qtpy.QtCore import Qt, QProcess
@@ -150,6 +150,11 @@ def test_unittestwidget_process_finished_abnormally_status_label(widget):
     widget.process_finished([], 'output', False)
     expected_text = '<b>{}</b>'.format('Test process exited abnormally')
     assert widget.status_label.text() == expected_text
+
+def test_unittestwidget_handles_sig_single_test_run_requested(widget):
+    with patch.object(widget, 'run_tests') as mock_run_tests:
+        widget.testdataview.sig_single_test_run_requested.emit('testname')
+        mock_run_tests.assert_called_once_with(single_test='testname')
 
 @pytest.mark.parametrize('framework', ['pytest', 'nose2'])
 def test_run_tests_and_display_results(qtbot, widget, tmpdir, monkeypatch, framework):

--- a/spyder_unittest/widgets/tests/test_unittestgui.py
+++ b/spyder_unittest/widgets/tests/test_unittestgui.py
@@ -156,9 +156,8 @@ def test_unittestwidget_handles_sig_single_test_run_requested(widget):
         widget.testdataview.sig_single_test_run_requested.emit('testname')
         mock_run_tests.assert_called_once_with(single_test='testname')
 
-@pytest.mark.parametrize(
-    'framework, alltests',
-    [('pytest', True), ('pytest', False), ('nose2', True)])
+@pytest.mark.parametrize('framework', ['pytest', 'nose2'])
+@pytest.mark.parametrize('alltests', [True, False])
 def test_run_tests_and_display_results(qtbot, widget, tmpdir, monkeypatch,
                                        framework, alltests):
     """Basic integration test."""

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -387,7 +387,7 @@ class UnitTestWidget(PluginMainWidget):
         executable = self.get_conf('executable', section='main_interpreter')
         try:
             self.testrunner.start(
-                config, cov_path, executable, pythonpath)
+                config, cov_path, executable, pythonpath, single_test)
         except RuntimeError:
             QMessageBox.critical(self,
                                  _("Error"), _("Process failed to start"))

--- a/spyder_unittest/widgets/unittestgui.py
+++ b/spyder_unittest/widgets/unittestgui.py
@@ -238,10 +238,6 @@ class UnitTestWidget(PluginMainWidget):
         """Set test configuration but do not emit any signal."""
         self._config = new_config
 
-    def use_dark_interface(self, flag):
-        """Set whether widget should use colours appropriate for dark UI."""
-        self.testdatamodel.is_dark_interface = flag
-
     def show_log(self):
         """Show output of testing process."""
         if self.output:


### PR DESCRIPTION
This PR adds the menu item "Run only this test" to the context menu that appears when right-clicking on a test result. Selecting this menu item re-runs the associated test only, ignoring all the other tests.

![singletest](https://github.com/spyder-ide/spyder-unittest/assets/7941918/bc00fc55-e182-4338-a1ce-525103eee7f8)

Fixes #88 