### PR TITLE
Update plugin and tests for Spyder 6.0.0a2 and 6.0.0a3

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,20 +14,21 @@ jobs:
       fail-fast: false 
       matrix:
         OS: ['ubuntu', 'macos', 'windows']
-        PYTHON_VERSION: ['3.8', '3.9', '3.10']
+        PYTHON_VERSION: ['3.9', '3.10', '3.11']
         SPYDER_SOURCE: ['conda', 'git']
         exclude:
-          - OS: 'macos'
-            PYTHON_VERSION: '3.8'
-            SPYDER_SOURCE: 'git'
+          # Remove some configurations to make CI tests run faster
           - OS: 'macos'
             PYTHON_VERSION: '3.9'
             SPYDER_SOURCE: 'git'
-          - OS: 'windows'
-            PYTHON_VERSION: '3.8'
+          - OS: 'macos'
+            PYTHON_VERSION: '3.10'
             SPYDER_SOURCE: 'git'
           - OS: 'windows'
             PYTHON_VERSION: '3.9'
+            SPYDER_SOURCE: 'git'
+          - OS: 'windows'
+            PYTHON_VERSION: '3.10'
             SPYDER_SOURCE: 'git'
     name: ${{ matrix.OS }} py${{ matrix.PYTHON_VERSION }} spyder-from-${{ matrix.SPYDER_SOURCE }}
     runs-on: ${{ matrix.OS }}-latest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,21 +15,10 @@ jobs:
       matrix:
         OS: ['ubuntu', 'macos', 'windows']
         PYTHON_VERSION: ['3.9', '3.10', '3.11']
-        SPYDER_SOURCE: ['conda', 'git']
-        exclude:
-          # Remove some configurations to make CI tests run faster
-          - OS: 'macos'
-            PYTHON_VERSION: '3.9'
-            SPYDER_SOURCE: 'git'
-          - OS: 'macos'
-            PYTHON_VERSION: '3.10'
-            SPYDER_SOURCE: 'git'
-          - OS: 'windows'
-            PYTHON_VERSION: '3.9'
-            SPYDER_SOURCE: 'git'
-          - OS: 'windows'
-            PYTHON_VERSION: '3.10'
-            SPYDER_SOURCE: 'git'
+        # Do not test against conda for the moment because latest Spyder
+        # version on conda-forge is 6.0.0alpha2 which is not compatible
+        # with Spyder's master branch
+        SPYDER_SOURCE: ['git']
     name: ${{ matrix.OS }} py${{ matrix.PYTHON_VERSION }} spyder-from-${{ matrix.SPYDER_SOURCE }}
     runs-on: ${{ matrix.OS }}-latest
     env:

--- a/spyder_unittest/unittestplugin.py
+++ b/spyder_unittest/unittestplugin.py
@@ -72,7 +72,8 @@ class UnitTestPlugin(SpyderDockablePlugin):
         """
         return _('Unit testing')
 
-    def get_description(self):
+    @staticmethod
+    def get_description():
         """
         Return the plugin localized description.
 
@@ -83,7 +84,8 @@ class UnitTestPlugin(SpyderDockablePlugin):
         """
         return _('Run test suites and view their results')
 
-    def get_icon(self):
+    @classmethod
+    def get_icon(cls):
         """
         Return the plugin associated icon.
 

--- a/spyder_unittest/widgets/confpage.py
+++ b/spyder_unittest/widgets/confpage.py
@@ -24,8 +24,9 @@ class UnitTestConfigPage(PluginConfigPage):
 
     def setup_page(self) -> None:
         settings_group = QGroupBox(_('Settings'))
-        self.abbrev_box = self.create_checkbox(
+        widget = self.create_checkbox(
             _('Abbreviate test names'), 'abbrev_test_names', default=False)
+        self.abbrev_box = widget.checkbox
 
         settings_layout = QVBoxLayout()
         settings_layout.addWidget(self.abbrev_box)

--- a/spyder_unittest/widgets/tests/test_confpage.py
+++ b/spyder_unittest/widgets/tests/test_confpage.py
@@ -71,9 +71,6 @@ class MainWindowMock(QMainWindow):
         if plugin_name in PLUGIN_REGISTRY:
             return PLUGIN_REGISTRY.get_plugin(plugin_name)
 
-    def set_prefs_size(self, size):
-        pass
-
 
 class ConfigDialogTester(QWidget):
     def __init__(self, parent, main_class,
@@ -82,9 +79,6 @@ class ConfigDialogTester(QWidget):
         self._main = main_class(self) if main_class else None
         if self._main is None:
             self._main = MainWindowMock(self)
-
-        def set_prefs_size(self, size):
-            pass
 
         def register_plugin(self, plugin_name, external=False):
             plugin = PLUGIN_REGISTRY.get_plugin(plugin_name)
@@ -101,8 +95,6 @@ class ConfigDialogTester(QWidget):
         #         types.MethodType(register_plugin, self._main))
         setattr(self._main, 'get_plugin',
                 types.MethodType(get_plugin, self._main))
-        setattr(self._main, 'set_prefs_size',
-                types.MethodType(set_prefs_size, self._main))
 
         PLUGIN_REGISTRY.reset()
         PLUGIN_REGISTRY.sig_plugin_ready.connect(self._main.register_plugin)
@@ -135,7 +127,7 @@ def config_dialog(qtbot, request):
     qtbot.addWidget(main_ref)
 
     preferences = main_ref._main.get_plugin(Plugins.Preferences)
-    preferences.open_dialog(None)
+    preferences.open_dialog()
     container = preferences.get_container()
     dlg = container.dialog
 


### PR DESCRIPTION
Follow updates in Spyder API from PRs spyder-ide/spyder#20926, spyder-ide/spyder#21101 and spyder-ide/spyder#21233. Also, replace Python 3.8 by Python 3.11 in GitHub automatic test.

Fixes #215.