### PR TITLE
PR: Don't install in editable mode in GitHub workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install Spyder from source
         if: matrix.SPYDER_SOURCE == 'git'
         shell: bash -l {0}
-        run: pip install --no-deps -e spyder
+        run: pip install --no-deps spyder
       - name: Install plugin dependencies (without Spyder)
         if: matrix.SPYDER_SOURCE == 'git'
         shell: bash -l {0}
@@ -76,7 +76,7 @@ jobs:
           mamba install --file spyder-unittest/requirements/tests.txt -y
       - name: Install plugin
         shell: bash -l {0}
-        run: pip install --no-deps -e spyder-unittest
+        run: pip install --no-deps spyder-unittest
       - name: Show environment information
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
Pip is reporting that installing a module as editable is deprecated, so don't do that in our GitHub test workflow. 

Inspired by spyder-ide/spyder#23384.