### PR TITLE
PR: Remove QTextCodec

### DIFF
--- a/spyder_unittest/backend/runnerbase.py
+++ b/spyder_unittest/backend/runnerbase.py
@@ -208,6 +208,7 @@ class RunnerBase(QObject):
         """
         self.process = self._prepare_process(config, pythonpath)
         p_args = self.create_argument_list(config, cov_path, single_test)
+        p_args = ['-X', 'utf8'] + p_args  # Ensure output is UTF-8
         try:
             os.remove(self.resultfilename)
         except OSError:
@@ -231,8 +232,7 @@ class RunnerBase(QObject):
         """Read and return all output from `self.process` as unicode."""
         assert self.process is not None
         qbytearray = self.process.readAllStandardOutput()
-        locale_codec = QTextCodec.codecForLocale()
-        return locale_codec.toUnicode(qbytearray.data())
+        return str(qbytearray.data(), encoding='utf-8')
 
     def stop_if_running(self) -> None:
         """Stop testing process if it is running."""

--- a/spyder_unittest/backend/tests/test_runnerbase.py
+++ b/spyder_unittest/backend/tests/test_runnerbase.py
@@ -88,5 +88,7 @@ def test_runnerbase_start(monkeypatch):
     with pytest.raises(RuntimeError):
         runner.start(config, cov_path, 'python_exec', ['pythondir'], None)
 
-    mock_process.start.assert_called_once_with('python_exec', ['arg1', 'arg2'])
+    mock_process.start.assert_called_once_with(
+        'python_exec', ['-X', 'utf8', 'arg1', 'arg2']
+    )
     mock_remove.assert_called_once_with('results')


### PR DESCRIPTION
Running Python with the -X utf8 option ensures that the output is encoded in UTF-8 so there is no need to use QTextCodec. This helps with the Qt6 transition.

Idea is taken from PR spyder-ide/spyder-line-profiler#99.

Fixes #224.