### PR TITLE
PR: Update CI tests for Spyder 6.1

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -74,9 +74,7 @@ jobs:
         run: conda install --file spyder-unittest/requirements/conda.txt -y
       - name: Install test dependencies
         shell: bash -l {0}
-        run: |
-          conda install nomkl -y -q
-          conda install --file spyder-unittest/requirements/tests.txt -y
+        run: conda install --file spyder-unittest/requirements/tests.txt -y
       - name: Install plugin
         shell: bash -l {0}
         run: python -m pip install --no-deps spyder-unittest/

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,8 +14,11 @@ jobs:
       fail-fast: false 
       matrix:
         OS: ['ubuntu', 'macos', 'windows']
-        PYTHON_VERSION: ['3.9', '3.11', '3.12']
-        SPYDER_SOURCE: ['git']
+        PYTHON_VERSION: ['3.10', '3.11', '3.12']
+        SPYDER_SOURCE: ['conda', 'git']
+        exclude:
+          - OS: ['macos', 'windows']
+            PYTHON_VERSION: ['3.11']
     name: ${{ matrix.OS }} py${{ matrix.PYTHON_VERSION }} spyder-from-${{ matrix.SPYDER_SOURCE }}
     runs-on: ${{ matrix.OS }}-latest
     env:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -39,6 +39,7 @@ jobs:
         with:
            miniforge-version: latest
            auto-update-conda: true
+           conda-remove-defaults: "true"
            python-version: ${{ matrix.PYTHON_VERSION }} 
       - name: Checkout Spyder from git
         if: matrix.SPYDER_SOURCE == 'git'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "spyder-unittest"
 description = "Plugin to run tests from within the Spyder IDE"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "MIT"
 license-files = ["LICENSE.txt"]
 authors = [{name = "Spyder Project Contributors"}]
@@ -18,7 +18,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/spyder_unittest/tests/conftest.py
+++ b/spyder_unittest/tests/conftest.py
@@ -10,6 +10,8 @@ This contains the necessary definitions to make the main_window fixture
 available for integration tests.
 """
 
+import time
+
 # Third-party imports
 from qtpy.QtWidgets import QApplication
 import pytest
@@ -22,6 +24,7 @@ from qtpy import QtWebEngineWidgets  # noqa
 from spyder import version_info as spyder_version_info
 from spyder.api.plugin_registration.registry import PLUGIN_REGISTRY
 from spyder.app import start
+from spyder.config.base import running_in_ci
 from spyder.config.manager import CONF
 
 
@@ -38,6 +41,11 @@ def main_window(monkeypatch):
     QApplication.processEvents()
 
     yield window
+
+    # This is to prevent "QThread: Thread still running" error
+    if running_in_ci():
+        time.sleep(5)
+        QApplication.processEvents()
 
     # Close main window
     window.closing(close_immediately=True)

--- a/spyder_unittest/tests/test_unittestplugin.py
+++ b/spyder_unittest/tests/test_unittestplugin.py
@@ -10,18 +10,33 @@ Tests for the integration of the plugin with Spyder.
 # Standard library imports
 from collections import OrderedDict
 import os
+import time
 
 # Third party imports
 from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication
 
 # Spyder imports
 from spyder import version_info as spyder_version_info
 from spyder.api.plugins import Plugins
+from spyder.config.base import running_in_ci
 from spyder.plugins.mainmenu.api import ApplicationMenus
 
 # Local imports
 from spyder_unittest.unittestplugin import UnitTestPlugin
 from spyder_unittest.widgets.configdialog import Config
+
+
+def sleep_if_running_in_ci():
+    """
+    Sleep if the tests are running in GitHub CI.
+
+    This prevents the error "QThread: Destroyed while thread is still running"
+    for some reason.
+    """
+    if running_in_ci():
+        time.sleep(5)
+        QApplication.processEvents()
 
 
 def test_menu_item(main_window):
@@ -66,9 +81,11 @@ def test_default_working_dir(main_window, tmpdir):
 
     assert unittest_plugin.get_widget().default_wdir == os.getcwd()
 
+    sleep_if_running_in_ci()
     projects.create_project(project_dir)
     assert unittest_plugin.get_widget().default_wdir == project_dir
 
+    sleep_if_running_in_ci()
     projects.close_project()
     assert unittest_plugin.get_widget().default_wdir == os.getcwd()
 
@@ -88,6 +105,7 @@ def test_plugin_config(main_window, tmpdir, qtbot):
     assert unittest_widget.config is None
 
     # Create new project
+    sleep_if_running_in_ci()
     projects.create_project(project_dir)
 
     # Test config file does exist but config is empty
@@ -102,14 +120,17 @@ def test_plugin_config(main_window, tmpdir, qtbot):
     assert 'framework = unittest' in config_file_path.read().splitlines()
 
     # Close project and test that config is empty
+    sleep_if_running_in_ci()
     projects.close_project()
     assert unittest_widget.config is None
 
     # Re-open project and test that config is correctly read
+    sleep_if_running_in_ci()
     projects.open_project(project_dir)
     assert unittest_widget.config == config
 
     # Close project before ending test, which removes the project dir
+    sleep_if_running_in_ci()
     projects.close_project()
 
 


### PR DESCRIPTION
- The CI tests with Spyder 6.1 fail with a "QThread: Thread still running" error. Prevent this by adding some sleeps.
- Drop support for Python 3.9 because it is no longer supported on conda-forge.
- Remove CI test runs for Python 3.11 on Mac and Windows to save resources.
- Add CI test runs for Spyder installed from conda now that Spyder 6.1 is released.
- Perform some cleanup in workflow file.

Fixes #229